### PR TITLE
[BID-61] rollup: add median polish and directlfq matrix rollups

### DIFF
--- a/msmu/_preprocessing/_summarisation.py
+++ b/msmu/_preprocessing/_summarisation.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -12,6 +13,89 @@ from typing import Literal
 
 
 logger = get_logger(__name__)
+
+MEDIAN_POLISH_MAX_ITERATIONS: int = 10
+# Relative convergence on the sum of absolute residuals, matching R's ``stats::medpolish``
+# (the summarisation used by MSstats). Median polish does not always converge to a unique
+# fixed point on data with missing values, so this stops at the standard residual criterion
+# rather than iterating to machine precision.
+MEDIAN_POLISH_CONVERGENCE_TOLERANCE: float = 1e-4
+
+
+def _median_polish(feature_by_sample_matrix: np.ndarray) -> np.ndarray:
+    """Summarise a feature-by-sample matrix to per-sample estimates via Tukey's median polish.
+
+    Median polish fits the additive model ``value[feature, sample] = overall +
+    row_effect[feature] + col_effect[sample] + residual`` by iteratively sweeping row
+    and column medians out of the matrix. The rollup estimate for each sample is
+    ``overall + col_effect[sample]``.
+
+    Convergence follows R's ``stats::medpolish`` (MSstats' summarisation): iterate until the
+    relative change in the sum of absolute residuals falls below
+    ``MEDIAN_POLISH_CONVERGENCE_TOLERANCE`` or ``MEDIAN_POLISH_MAX_ITERATIONS`` is reached.
+    Convergence on ``overall`` alone is NOT sufficient — it can stabilise while the row/column
+    effects are still moving, stopping early with a wrong estimate.
+
+    IMPORTANT: this is an *additive* model, so it must be applied to log-space
+    intensities (e.g. log2). Applying it to linear intensities is not meaningful.
+
+    NaN handling: missing values are ignored via ``nanmedian``. A sample column with no
+    observed values across every feature yields ``NaN`` (there is nothing to summarise).
+
+    Args:
+        feature_by_sample_matrix (np.ndarray): 2D array of log-space intensities with
+            shape ``(n_features, n_samples)``. May contain NaN for missing values.
+
+    Returns:
+        np.ndarray: 1D array of length ``n_samples`` with the per-sample rollup estimate.
+    """
+    residual_matrix = np.array(feature_by_sample_matrix, dtype=float, copy=True)
+
+    if residual_matrix.ndim != 2:
+        raise ValueError("median polish expects a 2D feature-by-sample matrix.")
+
+    number_of_features, number_of_samples = residual_matrix.shape
+    fully_missing_sample_mask = np.all(np.isnan(residual_matrix), axis=0)
+
+    overall_effect: float = 0.0
+    row_effects = np.zeros(number_of_features, dtype=float)
+    col_effects = np.zeros(number_of_samples, dtype=float)
+    previous_residual_sum: float = np.inf
+
+    with warnings.catch_warnings():
+        # nanmedian legitimately hits all-NaN rows/columns for fully-missing features/samples.
+        warnings.filterwarnings(action="ignore", message="All-NaN slice encountered")
+        for iteration in range(MEDIAN_POLISH_MAX_ITERATIONS):
+            # Row sweep: remove the median of each feature (row) across samples.
+            row_medians = np.nan_to_num(np.nanmedian(residual_matrix, axis=1))
+            residual_matrix -= row_medians[:, np.newaxis]
+            row_effects += row_medians
+            col_alignment = np.nan_to_num(np.nanmedian(col_effects))
+            col_effects -= col_alignment
+            overall_effect += col_alignment
+
+            # Column sweep: remove the median of each sample (column) across features.
+            col_medians = np.nan_to_num(np.nanmedian(residual_matrix, axis=0))
+            residual_matrix -= col_medians[np.newaxis, :]
+            col_effects += col_medians
+            row_alignment = np.nan_to_num(np.nanmedian(row_effects))
+            row_effects -= row_alignment
+            overall_effect += row_alignment
+
+            # Convergence on the sum of absolute residuals (R medpolish criterion).
+            current_residual_sum = float(np.nansum(np.abs(residual_matrix)))
+            if current_residual_sum == 0.0:
+                break
+            if iteration > 0 and abs(previous_residual_sum - current_residual_sum) < (
+                MEDIAN_POLISH_CONVERGENCE_TOLERANCE * current_residual_sum
+            ):
+                break
+            previous_residual_sum = current_residual_sum
+
+    sample_estimates = overall_effect + col_effects
+    sample_estimates[fully_missing_sample_mask] = np.nan
+
+    return sample_estimates
 
 
 class FeatureRanker:
@@ -150,13 +234,13 @@ class Aggregator:
         identification_df: pd.DataFrame,
         quantification_df: pd.DataFrame,
         decoy_df: pd.DataFrame | None,
-        agg_method: Literal["median", "mean", "sum"],
+        agg_method: Literal["median", "mean", "sum", "median_polish"],
         score_method: Literal["best_pep"],
     ) -> None:
         self._id_df: pd.DataFrame = identification_df.copy()
         self._quant_df: pd.DataFrame = quantification_df.copy()
         self._decoy_id_df: pd.DataFrame = decoy_df.copy() if decoy_df is not None else pd.DataFrame()
-        self._agg_method: Literal["median", "mean", "sum"] = agg_method
+        self._agg_method: Literal["median", "mean", "sum", "median_polish"] = agg_method
         self._score_method: Literal["best_pep"] = score_method
 
         self._id_agg_dict: dict = dict()  # placeholder
@@ -262,9 +346,22 @@ class Aggregator:
         return agg_id_df
 
     def aggregate_quantification(self) -> pd.DataFrame:
+        sample_columns = self._quant_df.columns
         agg_quant_df: pd.DataFrame = self._quant_df.copy()
         agg_quant_df[self._col_to_groupby] = self._id_df[self._col_to_groupby]
-        agg_quant_df = agg_quant_df.groupby(self._col_to_groupby, observed=False).agg(self._agg_method)
+        grouped_quant = agg_quant_df.groupby(self._col_to_groupby, observed=False)
+
+        if self._agg_method == "median_polish":
+            # Median polish operates on each group's full feature-by-sample submatrix,
+            # so it cannot be expressed as a column-wise pandas aggregation.
+            agg_quant_df = grouped_quant[sample_columns].apply(
+                lambda group_quant: pd.Series(
+                    _median_polish(group_quant.to_numpy(dtype=float)),
+                    index=sample_columns,
+                )
+            )
+        else:
+            agg_quant_df = grouped_quant.agg(self._agg_method)
 
         agg_quant_df = agg_quant_df.rename_axis(index=None)
 

--- a/msmu/_preprocessing/_summarisation.py
+++ b/msmu/_preprocessing/_summarisation.py
@@ -21,6 +21,97 @@ MEDIAN_POLISH_MAX_ITERATIONS: int = 10
 # rather than iterating to machine precision.
 MEDIAN_POLISH_CONVERGENCE_TOLERANCE: float = 1e-4
 
+# directlfq's within-protein normalisation caps how many samples it uses to build the
+# pairwise-shift graph (directlfq's ``number_of_quadratic_samples`` default) and requires at
+# least this many observed ions to emit a protein estimate.
+DIRECTLFQ_NUM_SAMPLES_QUADRATIC: int = 10
+DIRECTLFQ_MIN_NON_MISSING_IONS: int = 1
+
+# directlfq's low-level per-protein worker (unlike its top-level ``run_lfq``) never runs the
+# copy-flag probe itself. On pandas>=3 / numpy>=2, ``DataFrame.to_numpy()`` returns a read-only
+# (copy-on-write) array that directlfq's in-place sample shift cannot mutate, so the flag has to
+# be set before the first call. Guarded so the one-off configuration runs at most once per process.
+_directlfq_runtime_configured: bool = False
+
+
+def _directlfq_rollup(feature_by_sample_matrix: np.ndarray) -> np.ndarray:
+    """Summarise a feature-by-sample matrix to per-sample estimates via directlfq (DirectLFQ).
+
+    DirectLFQ (Ammar et al. 2023) aligns each feature's intensity trace onto a common scale
+    (a within-group "peptide shift") and takes the per-sample median of the aligned traces.
+    It is a fast, MaxLFQ-inspired label-free quantification method, but a *distinct* algorithm
+    from the classical MaxLFQ pairwise-ratio least-squares — the results are correlated, not
+    identical.
+
+    This calls directlfq's per-protein worker on a single group's submatrix, so the estimate for
+    each group depends only on that group's own features (directlfq's cross-group step is its
+    between-sample normalisation, which is skipped here — msmu handles normalisation upstream).
+    That keeps this rollup a drop-in per-group aggregation, symmetric with ``_median_polish``.
+
+    IMPORTANT: like median polish this operates in log space. directlfq's per-protein worker
+    consumes log2 intensities and returns a log2-space profile, so the input must be log2
+    (e.g. apply log2_transform first) and the output is log2.
+
+    NaN handling: missing values propagate as directlfq's own missingness. Features (rows) with
+    no observed values are dropped before the call; a sample column with no observed values
+    across every feature yields ``NaN``.
+
+    Args:
+        feature_by_sample_matrix (np.ndarray): 2D array of log-space intensities with
+            shape ``(n_features, n_samples)``. May contain NaN for missing values.
+
+    Returns:
+        np.ndarray: 1D array of length ``n_samples`` with the per-sample rollup estimate.
+    """
+    global _directlfq_runtime_configured
+
+    import directlfq.config as directlfq_config
+    import directlfq.protein_intensity_estimation as directlfq_estimation
+
+    if not _directlfq_runtime_configured:
+        directlfq_config.check_wether_to_copy_numpy_arrays_derived_from_pandas()
+        # The worker is called once per group with idx=0, and directlfq logs an INFO line
+        # whenever idx % 100 == 0 (always true at idx=0). Left on, that emits one identical
+        # "lfq-object 0" line per protein group — thousands of lines on a real run.
+        directlfq_config.set_log_processed_proteins(log_processed_proteins=False)
+        _directlfq_runtime_configured = True
+
+    matrix = np.asarray(feature_by_sample_matrix, dtype=float)
+    if matrix.ndim != 2:
+        raise ValueError("directlfq rollup expects a 2D feature-by-sample matrix.")
+
+    _number_of_features, number_of_samples = matrix.shape
+    sample_estimates = np.full(number_of_samples, np.nan, dtype=float)
+
+    # Drop features with no observed values; they contribute nothing and match directlfq's own
+    # all-NaN-row removal. A fully-missing sample column is preserved and returns NaN.
+    observed_feature_mask = ~np.all(np.isnan(matrix), axis=1)
+    if not observed_feature_mask.any():
+        return sample_estimates
+
+    observed_matrix = matrix[observed_feature_mask]
+    peptide_by_sample_df = pd.DataFrame(
+        observed_matrix,
+        index=pd.MultiIndex.from_arrays(
+            [
+                np.zeros(observed_matrix.shape[0], dtype=int),  # single protein group
+                np.arange(observed_matrix.shape[0]),  # ion (feature) identifiers
+            ],
+            names=[directlfq_config.PROTEIN_ID, directlfq_config.QUANT_ID],
+        ),
+    )
+
+    protein_profile, _shifted_peptides = directlfq_estimation.calculate_peptide_and_protein_intensities(
+        0,
+        peptide_by_sample_df,
+        DIRECTLFQ_NUM_SAMPLES_QUADRATIC,
+        DIRECTLFQ_MIN_NON_MISSING_IONS,
+    )
+    if protein_profile is None:
+        return sample_estimates
+
+    return np.asarray(protein_profile, dtype=float)
+
 
 def _median_polish(feature_by_sample_matrix: np.ndarray) -> np.ndarray:
     """Summarise a feature-by-sample matrix to per-sample estimates via Tukey's median polish.
@@ -234,13 +325,13 @@ class Aggregator:
         identification_df: pd.DataFrame,
         quantification_df: pd.DataFrame,
         decoy_df: pd.DataFrame | None,
-        agg_method: Literal["median", "mean", "sum", "median_polish"],
+        agg_method: Literal["median", "mean", "sum", "median_polish", "directlfq"],
         score_method: Literal["best_pep"],
     ) -> None:
         self._id_df: pd.DataFrame = identification_df.copy()
         self._quant_df: pd.DataFrame = quantification_df.copy()
         self._decoy_id_df: pd.DataFrame = decoy_df.copy() if decoy_df is not None else pd.DataFrame()
-        self._agg_method: Literal["median", "mean", "sum", "median_polish"] = agg_method
+        self._agg_method: Literal["median", "mean", "sum", "median_polish", "directlfq"] = agg_method
         self._score_method: Literal["best_pep"] = score_method
 
         self._id_agg_dict: dict = dict()  # placeholder
@@ -351,12 +442,17 @@ class Aggregator:
         agg_quant_df[self._col_to_groupby] = self._id_df[self._col_to_groupby]
         grouped_quant = agg_quant_df.groupby(self._col_to_groupby, observed=False)
 
-        if self._agg_method == "median_polish":
-            # Median polish operates on each group's full feature-by-sample submatrix,
-            # so it cannot be expressed as a column-wise pandas aggregation.
+        # Matrix rollups operate on each group's full feature-by-sample submatrix, so they cannot
+        # be expressed as a column-wise pandas aggregation and are applied per group instead.
+        matrix_rollups = {
+            "median_polish": _median_polish,
+            "directlfq": _directlfq_rollup,
+        }
+        if self._agg_method in matrix_rollups:
+            rollup_function = matrix_rollups[self._agg_method]
             agg_quant_df = grouped_quant[sample_columns].apply(
                 lambda group_quant: pd.Series(
-                    _median_polish(group_quant.to_numpy(dtype=float)),
+                    rollup_function(group_quant.to_numpy(dtype=float)),
                     index=sample_columns,
                 )
             )

--- a/msmu/_preprocessing/_summarise.py
+++ b/msmu/_preprocessing/_summarise.py
@@ -22,12 +22,18 @@ warnings.filterwarnings(action="ignore", message="Mean of empty slice")
 
 logger = get_logger(__name__)
 
+# median_polish and directlfq model per-feature response factors, which is meaningful when
+# combining distinct peptides into a protein but not when combining PSMs of the same peptide
+# (replicate measurements, typically 1-3 per peptide). PSM->peptide is restricted to the
+# column-wise reductions; the matrix rollups belong to the peptide->protein step (to_protein).
+PEPTIDE_AGG_METHODS: tuple[str, ...] = ("median", "mean", "sum")
+
 
 @uns_logger
 def to_peptide(
     mdata: md.MuData,
     layer: str | None = None,
-    agg_method: Literal["median", "mean", "sum", "median_polish"] = "median",
+    agg_method: Literal["median", "mean", "sum"] = "median",
     purity_threshold: float | None = 0.7,  # for tmt data
     top_n: int | None = None,
     rank_method: Literal["median_intensity", "total_intensity", "max_intensity", "mean_intensity"] = "median_intensity",
@@ -46,7 +52,7 @@ def to_peptide(
     Parameters:
         mdata: MuData object containing PSM-level data.
         layer: Layer to use for quantification aggregation. If None, the default layer (.X) will be used. Defaults to None.
-        agg_method: Aggregation method for quantification to use. One of "median", "mean", "sum", or "median_polish". Defaults to "median". "median_polish" applies Tukey's median polish per group and assumes the quantification is in log2 space (apply log2_transform first).
+        agg_method: Aggregation method for quantification to use. One of "median", "mean", or "sum". Defaults to "median". The matrix rollups "median_polish" and "directlfq" are not offered here; they model per-peptide response factors and belong to the peptide-to-protein step (to_protein).
         purity_threshold: Purity threshold for TMT data quantification aggregation (does not filter out features). If None, no filtering is applied. Defaults to 0.7.
         top_n: Number of top features to consider for summarisation. If None, all features are used. Defaults to None.
         rank_method: Method to rank features when selecting top_n. Defaults to "median_intensity".
@@ -55,6 +61,13 @@ def to_peptide(
     Returns:
         MuData object containing peptide-level data.
     """
+    if agg_method not in PEPTIDE_AGG_METHODS:
+        raise ValueError(
+            f"to_peptide supports agg_method in {PEPTIDE_AGG_METHODS}, got {agg_method!r}. "
+            "The matrix rollups 'median_polish' and 'directlfq' model per-peptide response "
+            "factors and are intended for the peptide-to-protein step (to_protein)."
+        )
+
     mdata = mdata.copy()
     adata_to_summarise: ad.AnnData = get_anndata_mod(mdata, "psm")
     if layer is not None:
@@ -185,7 +198,7 @@ def to_peptide(
 def to_protein(
     mdata: md.MuData,
     layer: str | None = None,
-    agg_method: Literal["median", "mean", "sum", "median_polish"] = "median",
+    agg_method: Literal["median", "mean", "sum", "median_polish", "directlfq"] = "median",
     top_n: int | None = 3,
     rank_method: Literal["median_intensity", "total_intensity", "max_intensity", "mean_intensity"] = "median_intensity",
     calculate_q: bool = True,
@@ -196,7 +209,7 @@ def to_protein(
     Parameters:
         mdata: MuData object containing Peptide-level data.
         layer: Layer to use for quantification aggregation. If None, the default layer (.X) will be used. Defaults to None.
-        agg_method: Aggregation method to use. One of "median", "mean", "sum", or "median_polish". Defaults to "median". "median_polish" applies Tukey's median polish per protein group and assumes the quantification is in log2 space (apply log2_transform first).
+        agg_method: Aggregation method to use. One of "median", "mean", "sum", "median_polish", or "directlfq". Defaults to "median". "median_polish" applies Tukey's median polish per protein group and "directlfq" applies the DirectLFQ rollup per protein group; both assume the quantification is in log2 space (apply log2_transform first).
         top_n: Number of top peptides to consider for summarisation. If None, all peptides are used. Defaults to None.
         rank_method: Method to rank features when selecting top_n. Defaults to "median_intensity".
         calculate_q: Whether to calculate q-values. Defaults to True.
@@ -318,7 +331,7 @@ def to_ptm(
     modi_name: str,
     modification: str,
     layer: str | None = None,
-    agg_method: Literal["median", "mean", "sum", "median_polish"] = "median",
+    agg_method: Literal["median", "mean", "sum", "median_polish", "directlfq"] = "median",
     top_n: int | None = None,
     rank_method: Literal["median_intensity", "total_intensity", "max_intensity", "mean_intensity"] = "median_intensity",
 ) -> md.MuData:
@@ -329,7 +342,7 @@ def to_ptm(
         modi_name: Name of the PTM to summarise (e.g., "phospho"). Will be used in the output modality name (eg. phospho_site).
         modification: Modification string (e.g., "[+79.96633]", "(unimod:21)").
         layer: Layer to use for quantification aggregation. If None, the default layer (.X) will be used. Defaults to None.
-        agg_method: Aggregation method to use. One of "median", "mean", "sum", or "median_polish". Defaults to "median". "median_polish" applies Tukey's median polish per group and assumes the quantification is in log2 space (apply log2_transform first).
+        agg_method: Aggregation method to use. One of "median", "mean", "sum", "median_polish", or "directlfq". Defaults to "median". "median_polish" applies Tukey's median polish per group and "directlfq" applies the DirectLFQ rollup per group; both assume the quantification is in log2 space (apply log2_transform first).
         top_n: Number of top features to consider for summarisation. If None, all features are used. Defaults to None.
         rank_method: Method to rank features when selecting top_n. Defaults to "median_intensity".
 

--- a/msmu/_preprocessing/_summarise.py
+++ b/msmu/_preprocessing/_summarise.py
@@ -27,7 +27,7 @@ logger = get_logger(__name__)
 def to_peptide(
     mdata: md.MuData,
     layer: str | None = None,
-    agg_method: Literal["median", "mean", "sum"] = "median",
+    agg_method: Literal["median", "mean", "sum", "median_polish"] = "median",
     purity_threshold: float | None = 0.7,  # for tmt data
     top_n: int | None = None,
     rank_method: Literal["median_intensity", "total_intensity", "max_intensity", "mean_intensity"] = "median_intensity",
@@ -46,7 +46,7 @@ def to_peptide(
     Parameters:
         mdata: MuData object containing PSM-level data.
         layer: Layer to use for quantification aggregation. If None, the default layer (.X) will be used. Defaults to None.
-        agg_method: Aggregation method for quantification to use. Defaults to "median".
+        agg_method: Aggregation method for quantification to use. One of "median", "mean", "sum", or "median_polish". Defaults to "median". "median_polish" applies Tukey's median polish per group and assumes the quantification is in log2 space (apply log2_transform first).
         purity_threshold: Purity threshold for TMT data quantification aggregation (does not filter out features). If None, no filtering is applied. Defaults to 0.7.
         top_n: Number of top features to consider for summarisation. If None, all features are used. Defaults to None.
         rank_method: Method to rank features when selecting top_n. Defaults to "median_intensity".
@@ -185,7 +185,7 @@ def to_peptide(
 def to_protein(
     mdata: md.MuData,
     layer: str | None = None,
-    agg_method: Literal["median", "mean", "sum"] = "median",
+    agg_method: Literal["median", "mean", "sum", "median_polish"] = "median",
     top_n: int | None = 3,
     rank_method: Literal["median_intensity", "total_intensity", "max_intensity", "mean_intensity"] = "median_intensity",
     calculate_q: bool = True,
@@ -196,7 +196,7 @@ def to_protein(
     Parameters:
         mdata: MuData object containing Peptide-level data.
         layer: Layer to use for quantification aggregation. If None, the default layer (.X) will be used. Defaults to None.
-        agg_method: Aggregation method to use. Defaults to "median".
+        agg_method: Aggregation method to use. One of "median", "mean", "sum", or "median_polish". Defaults to "median". "median_polish" applies Tukey's median polish per protein group and assumes the quantification is in log2 space (apply log2_transform first).
         top_n: Number of top peptides to consider for summarisation. If None, all peptides are used. Defaults to None.
         rank_method: Method to rank features when selecting top_n. Defaults to "median_intensity".
         calculate_q: Whether to calculate q-values. Defaults to True.
@@ -318,7 +318,7 @@ def to_ptm(
     modi_name: str,
     modification: str,
     layer: str | None = None,
-    agg_method: Literal["median", "mean", "sum"] = "median",
+    agg_method: Literal["median", "mean", "sum", "median_polish"] = "median",
     top_n: int | None = None,
     rank_method: Literal["median_intensity", "total_intensity", "max_intensity", "mean_intensity"] = "median_intensity",
 ) -> md.MuData:
@@ -329,7 +329,7 @@ def to_ptm(
         modi_name: Name of the PTM to summarise (e.g., "phospho"). Will be used in the output modality name (eg. phospho_site).
         modification: Modification string (e.g., "[+79.96633]", "(unimod:21)").
         layer: Layer to use for quantification aggregation. If None, the default layer (.X) will be used. Defaults to None.
-        agg_method: Aggregation method to use. Defaults to "median".
+        agg_method: Aggregation method to use. One of "median", "mean", "sum", or "median_polish". Defaults to "median". "median_polish" applies Tukey's median polish per group and assumes the quantification is in log2 space (apply log2_transform first).
         top_n: Number of top features to consider for summarisation. If None, all features are used. Defaults to None.
         rank_method: Method to rank features when selecting top_n. Defaults to "median_intensity".
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dynamic = ["version"]
 dependencies = [
     "anndata>=0.12.0",
     "biopython>=1.86",
+    "directlfq>=0.3.3,<0.4",
     "fastparquet>=2025.12.0",
     "inmoose>=0.9.1",
     "kaleido>=1.2.0",

--- a/tests/test_preprocessing_summarisation.py
+++ b/tests/test_preprocessing_summarisation.py
@@ -7,6 +7,7 @@ from msmu._preprocessing._summarisation import (
     FeatureRanker,
     Scorer,
     SummarisationPrep,
+    _directlfq_rollup,
     _median_polish,
 )
 
@@ -145,6 +146,94 @@ def test_aggregator_quantification_median_polish():
     assert list(quant.columns) == ["s1", "s2"]
     # Protein B has a single peptide, so its estimate is just that peptide's value.
     np.testing.assert_allclose(quant.loc["B", ["s1", "s2"]].to_numpy(dtype=float), [5.0, 6.0], atol=1e-8)
+
+
+def test_directlfq_rollup_additive_matrix_recovers_column_effects():
+    # DirectLFQ aligns feature traces then medians; on an exactly additive log2 matrix the
+    # per-sample profile should recover the column effects up to a constant offset.
+    row_effects = np.array([0.0, 1.0, 2.0, 3.0])
+    col_effects = np.array([10.0, 11.0, 12.0])
+    matrix = row_effects[:, None] + col_effects[None, :]
+
+    estimates = _directlfq_rollup(matrix)
+
+    # The absolute level is anchored by directlfq; only the between-sample shape is defined.
+    centered = estimates - estimates[0]
+    np.testing.assert_allclose(centered, col_effects - col_effects[0], atol=1e-8)
+
+
+def test_directlfq_rollup_is_robust_to_a_single_outlier_peptide():
+    base = np.array([0.0, 1.0, 2.0, 3.0])[:, None] + np.array([10.0, 11.0, 12.0])[None, :]
+    with_outlier = base.copy()
+    with_outlier[0, :] = with_outlier[0, :] + 8.0  # one wildly shifted peptide
+
+    estimates = _directlfq_rollup(with_outlier)
+
+    centered = estimates - estimates[0]
+    np.testing.assert_allclose(centered, [0.0, 1.0, 2.0], atol=1e-8)
+
+
+def test_directlfq_rollup_single_feature_returns_that_feature():
+    estimates = _directlfq_rollup(np.array([[10.0, 11.0, 12.0]]))
+    np.testing.assert_allclose(estimates, [10.0, 11.0, 12.0], atol=1e-8)
+
+
+def test_directlfq_rollup_fully_missing_sample_is_nan():
+    matrix = np.array(
+        [
+            [10.0, np.nan, 12.0],
+            [11.0, np.nan, 13.0],
+        ]
+    )
+    estimates = _directlfq_rollup(matrix)
+
+    assert np.isnan(estimates[1])  # sample 1 has no observations at all
+    assert not np.isnan(estimates[0])
+    assert not np.isnan(estimates[2])
+
+
+def test_directlfq_rollup_all_missing_matrix_is_all_nan():
+    estimates = _directlfq_rollup(np.full((3, 3), np.nan))
+    assert np.all(np.isnan(estimates))
+
+
+def test_aggregator_quantification_directlfq():
+    id_df = pd.DataFrame(
+        {
+            "peptide": ["p1", "p2", "p3"],
+            "protein_group": ["A", "A", "B"],
+            "stripped_peptide": ["p1", "p2", "p3"],
+            "PEP": [0.1, 0.2, 0.3],
+        },
+        index=["f1", "f2", "f3"],
+    )
+    quant_df = pd.DataFrame(
+        {"s1": [10.0, 12.0, 5.0], "s2": [11.0, 13.0, 6.0]},
+        index=id_df.index,
+    )
+    agg = Aggregator.protein(
+        identification_df=id_df,
+        quantification_df=quant_df,
+        decoy_df=None,
+        agg_method="directlfq",
+        score_method="best_pep",
+        protein_col="protein_group",
+    )
+    quant = agg.aggregate_quantification()
+
+    # Two protein groups, both samples present.
+    assert sorted(quant.index) == ["A", "B"]
+    assert list(quant.columns) == ["s1", "s2"]
+    # Protein B has a single peptide, so its estimate is just that peptide's value.
+    np.testing.assert_allclose(quant.loc["B", ["s1", "s2"]].to_numpy(dtype=float), [5.0, 6.0], atol=1e-8)
+
+
+@pytest.mark.parametrize("rejected_method", ["median_polish", "directlfq"])
+def test_to_peptide_rejects_matrix_rollups(mdata, rejected_method):
+    from msmu._preprocessing._summarise import to_peptide
+
+    with pytest.raises(ValueError, match="to_protein"):
+        to_peptide(mdata, agg_method=rejected_method)
 
 
 def test_summarisation_prep_filters_and_ranks(simple_adata):

--- a/tests/test_preprocessing_summarisation.py
+++ b/tests/test_preprocessing_summarisation.py
@@ -7,6 +7,7 @@ from msmu._preprocessing._summarisation import (
     FeatureRanker,
     Scorer,
     SummarisationPrep,
+    _median_polish,
 )
 
 
@@ -53,6 +54,97 @@ def test_aggregator_peptide_quantification():
     quant = agg.aggregate_quantification()
     assert ident.loc["p1", "count_psm"] == 2
     assert quant.shape[0] == 2
+
+
+def test_median_polish_additive_matrix_recovers_column_effects():
+    # An exactly additive matrix: value = overall + row_effect + col_effect.
+    overall = 5.0
+    row_effects = np.array([0.0, 1.0, -2.0])
+    col_effects = np.array([0.0, 3.0, -1.0, 2.0])
+    matrix = overall + row_effects[:, None] + col_effects[None, :]
+
+    estimates = _median_polish(matrix)
+
+    # Per-sample estimate should equal overall + col_effect (row median is 0 here).
+    expected = overall + col_effects
+    np.testing.assert_allclose(estimates, expected, atol=1e-8)
+
+
+def test_median_polish_is_robust_to_a_single_outlier_peptide():
+    base = np.array(
+        [
+            [10.0, 11.0, 12.0],
+            [10.0, 11.0, 12.0],
+            [10.0, 11.0, 12.0],
+        ]
+    )
+    with_outlier = base.copy()
+    with_outlier[0, 0] = 100.0  # one wildly high peptide value
+
+    estimates = _median_polish(with_outlier)
+
+    # The outlier should not drag the sample-0 estimate away from the consensus.
+    np.testing.assert_allclose(estimates, [10.0, 11.0, 12.0], atol=1e-8)
+
+
+def test_median_polish_handles_missing_values():
+    matrix = np.array(
+        [
+            [10.0, np.nan, 12.0],
+            [10.0, 11.0, np.nan],
+            [np.nan, np.nan, np.nan],  # sample 1 has no other observation -> stays NaN here
+        ]
+    )
+    estimates = _median_polish(matrix)
+
+    assert not np.isnan(estimates[0])
+    assert not np.isnan(estimates[1])  # sample 1 still has one observed value (row 1)
+    assert not np.isnan(estimates[2])
+
+
+def test_median_polish_fully_missing_sample_is_nan():
+    matrix = np.array(
+        [
+            [10.0, np.nan, 12.0],
+            [11.0, np.nan, 13.0],
+        ]
+    )
+    estimates = _median_polish(matrix)
+
+    assert np.isnan(estimates[1])  # sample 1 has no observations at all
+    assert not np.isnan(estimates[0])
+    assert not np.isnan(estimates[2])
+
+
+def test_aggregator_quantification_median_polish():
+    id_df = pd.DataFrame(
+        {
+            "peptide": ["p1", "p2", "p3"],
+            "protein_group": ["A", "A", "B"],
+            "stripped_peptide": ["p1", "p2", "p3"],
+            "PEP": [0.1, 0.2, 0.3],
+        },
+        index=["f1", "f2", "f3"],
+    )
+    quant_df = pd.DataFrame(
+        {"s1": [10.0, 12.0, 5.0], "s2": [11.0, 13.0, 6.0]},
+        index=id_df.index,
+    )
+    agg = Aggregator.protein(
+        identification_df=id_df,
+        quantification_df=quant_df,
+        decoy_df=None,
+        agg_method="median_polish",
+        score_method="best_pep",
+        protein_col="protein_group",
+    )
+    quant = agg.aggregate_quantification()
+
+    # Two protein groups, both samples present.
+    assert sorted(quant.index) == ["A", "B"]
+    assert list(quant.columns) == ["s1", "s2"]
+    # Protein B has a single peptide, so its estimate is just that peptide's value.
+    np.testing.assert_allclose(quant.loc["B", ["s1", "s2"]].to_numpy(dtype=float), [5.0, 6.0], atol=1e-8)
 
 
 def test_summarisation_prep_filters_and_ranks(simple_adata):


### PR DESCRIPTION
## Summary
Extend protein rollup with matrix-based methods (median polish, DirectLFQ), which reach MaxLFQ-grade quality on DIA data.

Parent BID-61 / subtasks BID-67 (median polish), BID-68 (directlfq)

## Changes
- median polish rollup — `agg_method="median_polish"` (4fa9a97)
- directlfq rollup — `agg_method="directlfq"`, DirectLFQ per-protein worker; matrix rollups restricted to the peptide→protein step, `to_peptide` limited to column reductions (median/mean/sum) with a guard (6919791)
- pin `directlfq>=0.3.3,<0.4`

## Testing
- `tests/test_preprocessing_summarisation.py` — median polish and directlfq units, plus the `to_peptide` matrix-rollup rejection guard
