### PR TITLE
[BID-66] DE: add limma moderated-t differential expression

### DIFF
--- a/msmu/_statistics/_de_base.py
+++ b/msmu/_statistics/_de_base.py
@@ -70,6 +70,10 @@ class StatTestResult:
         pct_ctrl: Percentage of non-zero values in the control group.
         pct_expr: Percentage of non-zero values in the experimental group.
         log2fc: Log2 fold change between experimental and control groups.
+        statistic: Per-feature test statistic. Its meaning depends on stat_method:
+            Welch/Student t, Wilcoxon rank-sum, or limma moderated t. For the
+            permutation path it is the observed parametric statistic (the value
+            ranked against the empirical null), while p_value stays empirical.
         p_value: P-values from the statistical test.
         q_value: Adjusted p-values (q-values) after multiple testing correction.
 
@@ -79,6 +83,7 @@ class StatTestResult:
     """
 
     stat_method: str
+    statistic: np.ndarray | None = None
     p_value: np.ndarray | None = None
     q_value: np.ndarray | None = None
 
@@ -128,6 +133,7 @@ class DeaResult:
                 "pct_ctrl": self.pct_ctrl,
                 "pct_expr": self.pct_expr,
                 "log2fc": self.log2fc,
+                "statistic": self.statistic,
                 "p_value": self.p_value,
                 "q_value": self.q_value,
             }

--- a/msmu/_statistics/_de_base.py
+++ b/msmu/_statistics/_de_base.py
@@ -113,6 +113,7 @@ class DeaResult:
     pct_ctrl: np.ndarray | None = None
     pct_expr: np.ndarray | None = None
     log2fc: np.ndarray | None = None
+    contrast_label: str | None = None
 
     def __init__(self, test_result: PermTestResult | StatTestResult) -> None:
         for field in test_result.__dataclass_fields__:

--- a/msmu/_statistics/_limma.py
+++ b/msmu/_statistics/_limma.py
@@ -1,0 +1,335 @@
+"""limma differential expression for msmu.
+
+A thin, domain-facing layer over inmoose's ``lmFit`` / ``contrasts_fit`` /
+``squeezeVar`` — a numerically exact Python port of Smyth's limma (validated
+bit-for-bit against R limma 3.62). The caller expresses a comparison in domain
+terms via one or two ``obs`` factors; this module builds the means-model design
+matrix and the numeric contrast vector internally, so raw contrast coefficients
+never surface in the public API.
+
+Two comparison levels are supported:
+
+* **Level 1** (``interaction=None``) — main effect ``expr - ctrl`` of a single factor.
+* **Level 2** (``interaction`` given) — interaction / difference-in-differences,
+  ``(expr - ctrl) @ interaction_level_a  -  (expr - ctrl) @ interaction_level_b``.
+
+Sign convention: a positive log2 fold change means higher in ``expr``.
+
+The eBayes B-statistic (``lods``) is intentionally not computed: inmoose 0.9.1's
+lods path has a DataFrame-indexing bug when the prior degrees of freedom diverge.
+Moderated t/p are computed directly from ``squeezeVar`` (the same posterior
+variance eBayes uses), which reproduces R limma's moderated t exactly.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from scipy.stats import t as t_distribution
+
+from ..logging_utils import get_logger
+from ._multiple_test_correction import PvalueCorrection
+
+logger = get_logger(__name__)
+
+POSITIVE_DIRECTION_NOTE = "positive log2 fold change means higher in 'expr'"
+
+
+@dataclass
+class LimmaContrast:
+    """A means-model design over sample cells plus the numeric contrast vector.
+
+    Attributes:
+        design: samples x design-columns DataFrame (one-hot cell means model,
+            optionally followed by covariate columns).
+        weights: contrast weight for each design column, in ``design`` column order.
+        label: human-readable description of the comparison.
+        kept_samples: the sample index entering the fit (subset of obs).
+        cell_columns: the design columns that are cell indicators (excludes covariates).
+    """
+
+    design: pd.DataFrame
+    weights: np.ndarray
+    label: str
+    kept_samples: pd.Index
+    cell_columns: list[str]
+
+
+@dataclass
+class LimmaResult:
+    """Per-feature limma moderated-t results, aligned to ``features``."""
+
+    features: np.ndarray
+    log2fc: np.ndarray
+    moderated_t: np.ndarray
+    p_value: np.ndarray
+    q_value: np.ndarray
+    contrast_label: str
+
+
+def _require_levels_present(values: pd.Series, column_name: str, requested_levels: list) -> None:
+    available = list(pd.unique(values.dropna()))
+    missing = [level for level in requested_levels if level not in available]
+    if missing:
+        raise ValueError(
+            f"Level(s) {missing} not found in obs column '{column_name}'. "
+            f"Available levels: {available}."
+        )
+
+
+def _resolve_interaction_levels(interaction_values: pd.Series, interaction_column: str, interaction_levels) -> list[str]:
+    if interaction_levels is None:
+        resolved = sorted((str(level) for level in pd.unique(interaction_values.dropna())))
+    else:
+        resolved = [str(level) for level in interaction_levels]
+    if len(resolved) != 2:
+        raise ValueError(
+            f"Interaction factor '{interaction_column}' requires exactly 2 levels, got {len(resolved)}: "
+            f"{resolved}. Pass interaction_levels=[level_a, level_b] to select two."
+        )
+    _require_levels_present(interaction_values.astype(str), interaction_column, resolved)
+    return resolved
+
+
+def _build_covariate_design(obs: pd.DataFrame, kept_samples: pd.Index, covariates: list[str] | None):
+    """Return (covariate_design, n_covariate_columns). Numeric passed through, categorical one-hot drop-first."""
+    if not covariates:
+        return None, 0
+    frames = []
+    for covariate in covariates:
+        if covariate not in obs.columns:
+            raise KeyError(f"Covariate column '{covariate}' not found in obs. Available: {list(obs.columns)}")
+        column = obs.loc[kept_samples, covariate]
+        if pd.api.types.is_numeric_dtype(column):
+            frames.append(column.astype(float).to_frame(name=f"cov_{covariate}"))
+        else:
+            dummies = pd.get_dummies(column.astype(str), prefix=f"cov_{covariate}", drop_first=True)
+            frames.append(dummies.astype(float))
+    covariate_design = pd.concat(frames, axis=1)
+    return covariate_design, covariate_design.shape[1]
+
+
+def build_contrast(
+    obs: pd.DataFrame,
+    category: str,
+    ctrl: str,
+    expr: str,
+    interaction: str | None = None,
+    interaction_levels=None,
+    covariates: list[str] | None = None,
+) -> LimmaContrast:
+    """Build the means-model design and the contrast vector for a Level 1 or Level 2 comparison."""
+    if category not in obs.columns:
+        raise KeyError(f"Column '{category}' not found in obs. Available: {list(obs.columns)}")
+    _require_levels_present(obs[category], category, [ctrl, expr])
+
+    if interaction is None:
+        keep_mask = obs[category].isin([ctrl, expr])
+        kept_samples = obs.index[keep_mask]
+        category_values = obs.loc[kept_samples, category].astype(str)
+        cell_columns = [str(ctrl), str(expr)]
+        cell_design = pd.DataFrame(
+            {level: (category_values == level).astype(float).to_numpy() for level in cell_columns},
+            index=kept_samples,
+        )
+        weight_map = {str(ctrl): -1.0, str(expr): 1.0}
+        label = f"{expr} vs {ctrl}"
+    else:
+        if interaction not in obs.columns:
+            raise KeyError(f"Column '{interaction}' not found in obs. Available: {list(obs.columns)}")
+        level_a, level_b = _resolve_interaction_levels(obs[interaction], interaction, interaction_levels)
+        keep_mask = obs[category].isin([ctrl, expr]) & obs[interaction].astype(str).isin([level_a, level_b])
+        kept_samples = obs.index[keep_mask]
+        category_values = obs.loc[kept_samples, category].astype(str)
+        interaction_values = obs.loc[kept_samples, interaction].astype(str)
+
+        # Difference-in-differences: (expr@a - ctrl@a) - (expr@b - ctrl@b).
+        # weight = category_sign * interaction_sign, with ctrl=-1/expr=+1 and level_a=+1/level_b=-1.
+        cell_columns = []
+        weight_map = {}
+        cell_masks = {}
+        for category_level, category_sign in ((str(ctrl), -1.0), (str(expr), 1.0)):
+            for interaction_level, interaction_sign in ((level_a, 1.0), (level_b, -1.0)):
+                name = f"{category_level}|{interaction_level}"
+                cell_columns.append(name)
+                weight_map[name] = category_sign * interaction_sign
+                cell_masks[name] = (
+                    (category_values == category_level) & (interaction_values == interaction_level)
+                ).to_numpy()
+        cell_design = pd.DataFrame(
+            {name: cell_masks[name].astype(float) for name in cell_columns},
+            index=kept_samples,
+        )
+        label = f"({expr} vs {ctrl}) interaction across {interaction}: {level_a} vs {level_b}"
+
+    empty_cells = [name for name in cell_columns if cell_design[name].sum() == 0]
+    if empty_cells:
+        raise ValueError(
+            f"No samples for cell(s) {empty_cells} in the requested comparison; "
+            f"cannot build the design. Check the level names in '{category}'"
+            + (f" and '{interaction}'." if interaction is not None else ".")
+        )
+
+    covariate_design, n_covariate_columns = _build_covariate_design(obs, kept_samples, covariates)
+    if covariate_design is not None:
+        design = pd.concat([cell_design, covariate_design], axis=1)
+    else:
+        design = cell_design
+
+    weights = np.array(
+        [weight_map[name] for name in cell_columns] + [0.0] * n_covariate_columns,
+        dtype=float,
+    )
+    return LimmaContrast(
+        design=design,
+        weights=weights,
+        label=label,
+        kept_samples=kept_samples,
+        cell_columns=cell_columns,
+    )
+
+
+def _estimable_feature_mask(
+    expr_matrix: pd.DataFrame,
+    contrast: LimmaContrast,
+    min_pct: float,
+) -> np.ndarray:
+    """Boolean mask over features (rows of ``expr_matrix``) that are testable for this contrast.
+
+    A feature is kept when every cell has at least ``min_pct`` (and at least one)
+    non-missing observation and the total residual degrees of freedom are positive.
+    This guarantees the per-gene observed design stays full rank, so inmoose's
+    NA-aware fit never hits a singular sub-design.
+    """
+    cell_design = contrast.design[contrast.cell_columns]
+    n_cells = len(contrast.cell_columns)
+    total_non_missing = np.zeros(expr_matrix.shape[0], dtype=float)
+    keep = np.ones(expr_matrix.shape[0], dtype=bool)
+    for cell in contrast.cell_columns:
+        cell_samples = cell_design.index[cell_design[cell] > 0]
+        cell_block = expr_matrix.loc[:, cell_samples].to_numpy()
+        non_missing = np.sum(~np.isnan(cell_block), axis=1)
+        total_non_missing += non_missing
+        required = max(1.0, min_pct * cell_samples.size)
+        keep &= non_missing >= required
+    keep &= total_non_missing > n_cells  # residual df >= 1
+    return keep
+
+
+def _fit_contrast(expr_matrix: pd.DataFrame, contrast: LimmaContrast) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Fit the contrast with inmoose and return (log2fc, moderated_t, p_value) per feature.
+
+    Moderated statistics are computed from ``squeezeVar`` directly to avoid inmoose
+    0.9.1's eBayes lods bug; this reproduces R limma's moderated t exactly.
+    """
+    from inmoose.limma import lmFit, contrasts_fit, squeezeVar
+
+    design = contrast.design
+    ordered_matrix = expr_matrix.loc[:, design.index]  # features x samples, aligned to design rows
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        fit = lmFit(ordered_matrix, design)
+        # inmoose renames design columns to positional labels (column0..N); align the
+        # contrast to those labels positionally.
+        contrast_frame = pd.DataFrame(
+            {"contrast": np.asarray(contrast.weights, dtype=float)},
+            index=list(fit.coefficients.columns),
+        )
+        contrast_fit = contrasts_fit(fit, contrast_frame)
+
+        sigma = np.asarray(contrast_fit.sigma, dtype=float)
+        df_residual = np.asarray(contrast_fit.df_residual, dtype=float)
+        squeezed = squeezeVar(sigma**2, df_residual)
+        posterior_variance = np.asarray(squeezed["var_post"], dtype=float)
+        df_prior = squeezed["df_prior"]
+
+        df_total = df_residual + df_prior
+        df_total = np.minimum(df_total, np.nansum(df_residual))
+
+        log2fc = np.asarray(contrast_fit.coefficients.iloc[:, 0], dtype=float)
+        stdev_unscaled = np.asarray(contrast_fit.stdev_unscaled.iloc[:, 0], dtype=float)
+        standard_error = stdev_unscaled * np.sqrt(posterior_variance)
+        moderated_t = log2fc / standard_error
+        p_value = 2.0 * t_distribution.sf(np.abs(moderated_t), df_total)
+
+    return log2fc, moderated_t, p_value
+
+
+def limma_de(
+    expr_matrix: pd.DataFrame,
+    obs: pd.DataFrame,
+    category: str,
+    ctrl: str,
+    expr: str,
+    interaction: str | None = None,
+    interaction_levels=None,
+    covariates: list[str] | None = None,
+    min_pct: float = 0.5,
+) -> LimmaResult:
+    """Run a limma moderated-t differential expression test.
+
+    Parameters:
+        expr_matrix: features x samples log2-intensity DataFrame (missing = NaN).
+        obs: sample metadata (index aligned to ``expr_matrix`` columns).
+        category: obs column holding the primary factor levels.
+        ctrl: reference level of ``category``.
+        expr: comparison level of ``category`` (positive log2FC = higher in ``expr``).
+        interaction: obs column of a second factor; if given, tests the interaction
+            (difference-in-differences) of ``expr - ctrl`` across two of its levels.
+        interaction_levels: the two ``interaction`` levels to contrast (defaults to the two present).
+        covariates: obs columns to adjust for (numeric passed through, categorical one-hot).
+        min_pct: minimum non-missing fraction required in every design cell.
+
+    Returns:
+        LimmaResult with per-feature log2fc, moderated t, p-value and BH q-value.
+    """
+    contrast = build_contrast(
+        obs=obs,
+        category=category,
+        ctrl=ctrl,
+        expr=expr,
+        interaction=interaction,
+        interaction_levels=interaction_levels,
+        covariates=covariates,
+    )
+
+    features = np.asarray(expr_matrix.index)
+    fit_matrix = expr_matrix.loc[:, contrast.kept_samples]
+
+    estimable_mask = _estimable_feature_mask(fit_matrix, contrast, min_pct)
+    n_estimable = int(np.sum(estimable_mask))
+    logger.debug(
+        "limma contrast '%s': %d/%d features estimable after min_pct=%.2f filter.",
+        contrast.label,
+        n_estimable,
+        features.size,
+        min_pct,
+    )
+    if n_estimable == 0:
+        raise ValueError(
+            f"No features pass the min_pct={min_pct} coverage filter for contrast '{contrast.label}'."
+        )
+
+    log2fc = np.full(features.size, np.nan)
+    moderated_t = np.full(features.size, np.nan)
+    p_value = np.full(features.size, np.nan)
+
+    estimable_matrix = fit_matrix.loc[estimable_mask]
+    fitted_log2fc, fitted_t, fitted_p = _fit_contrast(estimable_matrix, contrast)
+    log2fc[estimable_mask] = fitted_log2fc
+    moderated_t[estimable_mask] = fitted_t
+    p_value[estimable_mask] = fitted_p
+
+    q_value = PvalueCorrection.bh(p_value)
+
+    return LimmaResult(
+        features=features,
+        log2fc=log2fc,
+        moderated_t=moderated_t,
+        p_value=p_value,
+        q_value=q_value,
+        contrast_label=contrast.label,
+    )

--- a/msmu/_statistics/_permutation.py
+++ b/msmu/_statistics/_permutation.py
@@ -163,6 +163,8 @@ class PermutationTest:
         # put results to PermutationTestResult
         perm_test_res.p_value = pval_permutation
         perm_test_res.q_value = q_vals
+        # observed parametric statistic (the value ranked against the empirical null)
+        perm_test_res.statistic = obs_stats.statistic
 
         # Calculate the fold change percentile
         fc_pct_criteria = [1, 5]  # 1% and 5% thresholds

--- a/msmu/_statistics/_statistics.py
+++ b/msmu/_statistics/_statistics.py
@@ -331,6 +331,3 @@ def calc_permutation_pvalue(stat_obs: np.ndarray, null_dist: np.ndarray) -> np.n
     pvals[valid_mask] = (exceeded + 1) / (pooled_null.size + 1)
 
     return pvals
-
-
-class Limma: ...

--- a/msmu/_statistics/_statistics.py
+++ b/msmu/_statistics/_statistics.py
@@ -105,6 +105,7 @@ def simple_test(
 
     stat_res = StatTestResult(
         stat_method=test_res.stat_method,
+        statistic=test_res.statistic,
         p_value=test_res.p_value,
         q_value=corrected_pvals if fdr else None,
     )

--- a/msmu/_tools/_dea.py
+++ b/msmu/_tools/_dea.py
@@ -18,6 +18,7 @@ from .._statistics._statistics import (
     _calc_log2fc,
     _get_pct_expression,
 )
+from ._limma import _run_limma
 
 
 logger = get_logger(__name__)
@@ -62,11 +63,14 @@ def run_de(
     expr: str | None = None,
     min_pct: float = 0.5,
     layer: str | None = None,
-    stat_method: Literal["welch", "student", "wilcoxon"] = "welch",  # TODO: add "limma"
+    stat_method: Literal["welch", "student", "wilcoxon", "limma"] = "welch",
     measure: Literal["median", "mean"] = "median",
     n_resamples: int | None = 1000,
     fdr: bool | Literal["empirical", "bh"] = "empirical",
     log_transformed: bool = True,
+    interaction: str | None = None,
+    interaction_levels: list | None = None,
+    covariates: list[str] | None = None,
     _force_resample: bool = False,
 ) -> DeaResult:
     """
@@ -77,20 +81,46 @@ def run_de(
         modality: Modality name within the MuData to analyze.
         category: Observation category to define groups.
         ctrl: Name of the control group.
-        expr: Name of the experimental group. If None, all other groups are used.
+        expr: Name of the experimental group. If None, all other groups are used
+            (not supported for stat_method="limma", which needs an explicit group).
         layer: Layer to use for quantification aggregation. If None, the default layer (.X) will be used. Defaults to None.
-        stat_method: Statistical test to use ("welch", "student", "wilcoxon").
+        stat_method: Statistical test to use ("welch", "student", "wilcoxon", "limma").
         measure: Measure of central tendency to use ("median" or "mean") for fold-change.
         n_resamples: Number of resamples for permutation test. If None, no permutation test is performed.
         fdr: Method for multiple test correction ("empirical", "bh", or False).
         log_transformed: If True, data is assumed to be log-transformed. Defaults to True.
+        interaction: limma only — obs column of a second factor. If set, tests the
+            interaction (difference-in-differences) of ``expr - ctrl`` across two of its levels.
+        interaction_levels: limma only — the two ``interaction`` levels to contrast.
+        covariates: limma only — obs columns to adjust for.
         _force_resample: If True, forces resampling even if the number of resamples exceeds the number of combinations.
 
     Returns:
         DeaResult containing DE analysis results.
     """
-    if stat_method not in ["welch", "student", "wilcoxon"]:
-        raise ValueError(f"Invalid statistic: {stat_method}. Choose from 'welch', 'student', 'wilcoxon'.")
+    if stat_method not in ["welch", "student", "wilcoxon", "limma"]:
+        raise ValueError(
+            f"Invalid statistic: {stat_method}. Choose from 'welch', 'student', 'wilcoxon', 'limma'."
+        )
+
+    if stat_method == "limma":
+        if expr is None:
+            raise ValueError("stat_method='limma' requires an explicit 'expr' group (expr=None is not supported).")
+        return _run_limma(
+            mdata=mdata,
+            modality=modality,
+            category=category,
+            ctrl=ctrl,
+            expr=expr,
+            interaction=interaction,
+            interaction_levels=interaction_levels,
+            covariates=covariates,
+            min_pct=min_pct,
+            layer=layer,
+        )
+
+    if interaction is not None or interaction_levels is not None or covariates is not None:
+        raise ValueError("'interaction', 'interaction_levels' and 'covariates' are only supported with stat_method='limma'.")
     if fdr not in ["empirical", "bh", False]:
         raise ValueError("invalied fdr (mutiple test correction). Choose from 'empirical', 'bh', or False (bool)")
 

--- a/msmu/_tools/_limma.py
+++ b/msmu/_tools/_limma.py
@@ -1,0 +1,85 @@
+import mudata as md
+import pandas as pd
+
+from .._utils._mudata import get_anndata_mod
+from ..logging_utils import get_logger
+from .._statistics._de_base import DeaResult, StatTestResult
+from .._statistics._limma import limma_de
+from .._statistics._statistics import _measure_central_tendency, _get_pct_expression
+
+logger = get_logger(__name__)
+
+
+def _run_limma(
+    mdata: md.MuData,
+    modality: str,
+    category: str,
+    ctrl: str,
+    expr: str,
+    interaction: str | None = None,
+    interaction_levels: list | None = None,
+    covariates: list[str] | None = None,
+    min_pct: float = 0.5,
+    layer: str | None = None,
+) -> DeaResult:
+    """
+    Run limma moderated-t differential expression on a MuData modality.
+
+    Internal engine behind ``run_de(stat_method="limma")``. Positive log2 fold change
+    means higher in ``expr``. With ``interaction`` unset this tests the main effect
+    ``expr - ctrl``. With ``interaction`` set it tests the interaction /
+    difference-in-differences of ``expr - ctrl`` across two levels of the second
+    factor, e.g. "does the drug effect differ by genotype". The design matrix and
+    contrast are built internally; the caller never specifies raw contrast coefficients.
+    """
+    mod_adata = get_anndata_mod(mdata, modality)
+    if layer is not None:
+        data = pd.DataFrame(
+            mod_adata.layers[layer],
+            index=mod_adata.obs_names,
+            columns=mod_adata.var_names,
+        )
+    else:
+        data = mod_adata.to_df()
+    obs = mod_adata.obs
+    expr_matrix = data.T  # features x samples
+
+    result = limma_de(
+        expr_matrix=expr_matrix,
+        obs=obs,
+        category=category,
+        ctrl=ctrl,
+        expr=expr,
+        interaction=interaction,
+        interaction_levels=interaction_levels,
+        covariates=covariates,
+        min_pct=min_pct,
+    )
+    logger.debug(
+        "limma DEA for modality '%s' contrast '%s' produced %d features.",
+        modality,
+        result.contrast_label,
+        result.features.size,
+    )
+
+    test_res = StatTestResult(stat_method="limma", p_value=result.p_value, q_value=result.q_value)
+    de_res = DeaResult(test_res)
+    de_res.stat_method = "limma"
+    de_res.ctrl = ctrl
+    de_res.expr = expr
+    de_res.features = result.features
+    de_res.log2fc = result.log2fc
+    de_res.contrast_label = result.contrast_label
+
+    # Representative central tendency / detection percentage for the pooled expr-vs-ctrl
+    # groups, for volcano hover context (well-defined for main effect and interaction alike).
+    ctrl_samples = obs.index[obs[category] == ctrl]
+    expr_samples = obs.index[obs[category] == expr]
+    ctrl_arr = data.loc[ctrl_samples].to_numpy()
+    expr_arr = data.loc[expr_samples].to_numpy()
+    de_res.repr_ctrl = _measure_central_tendency(ctrl_arr, "median")
+    de_res.repr_expr = _measure_central_tendency(expr_arr, "median")
+    de_res.pct_ctrl = _get_pct_expression(ctrl_arr)
+    de_res.pct_expr = _get_pct_expression(expr_arr)
+
+    return de_res

--- a/msmu/_tools/_limma.py
+++ b/msmu/_tools/_limma.py
@@ -62,7 +62,12 @@ def _run_limma(
         result.features.size,
     )
 
-    test_res = StatTestResult(stat_method="limma", p_value=result.p_value, q_value=result.q_value)
+    test_res = StatTestResult(
+        stat_method="limma",
+        statistic=result.moderated_t,
+        p_value=result.p_value,
+        q_value=result.q_value,
+    )
     de_res = DeaResult(test_res)
     de_res.stat_method = "limma"
     de_res.ctrl = ctrl

--- a/tests/test_tools_limma.py
+++ b/tests/test_tools_limma.py
@@ -182,6 +182,20 @@ def test_covariate_adjustment_runs(level2_mdata):
 def test_result_frame_has_expected_columns(level1_mdata):
     res = run_de(level1_mdata, "protein", category="cond", ctrl="A", expr="B", stat_method="limma")
     frame = res.to_df()
-    for column in ["features", "log2fc", "p_value", "q_value"]:
+    for column in ["features", "log2fc", "statistic", "p_value", "q_value"]:
         assert column in frame.columns
     assert len(frame) == 6
+
+
+def test_statistic_field_is_moderated_t(level1_mdata):
+    res = run_de(level1_mdata, "protein", category="cond", ctrl="A", expr="B", stat_method="limma")
+    # limma surfaces the moderated t on DeaResult.statistic (aligned to features)
+    assert res.statistic is not None
+    assert res.statistic.size == res.features.size
+    # P1 is up in B (injected): positive log2fc AND positive moderated t, and the
+    # moderated t agrees in sign with the fold change everywhere it is defined
+    p1 = np.where(res.features == "P1")[0][0]
+    assert res.statistic[p1] > 0
+    assert np.isfinite(res.statistic[p1])
+    defined = np.isfinite(res.statistic) & np.isfinite(res.log2fc)
+    np.testing.assert_array_equal(np.sign(res.statistic[defined]), np.sign(res.log2fc[defined]))

--- a/tests/test_tools_limma.py
+++ b/tests/test_tools_limma.py
@@ -1,0 +1,187 @@
+"""Tests for limma moderated-t DE via msmu.tl.run_de(stat_method="limma").
+
+Golden values are from R limma 3.62 (lmFit -> contrasts.fit -> eBayes -> topTable)
+on the embedded fixed datasets, so this regression runs without R installed.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from anndata import AnnData
+from mudata import MuData
+
+from msmu._statistics._limma import build_contrast
+from msmu._tools._dea import run_de
+
+
+# --- fixed datasets (features x samples) and R limma golden outputs ----------------
+
+_Y1 = np.array(
+    [
+        [10.305, 8.96, 10.75, 12.441, 9.549, 10.198],
+        [10.128, 9.684, 9.983, 10.647, 12.379, 12.278],
+        [10.066, 11.127, 10.468, 9.141, 10.369, 9.041],
+        [10.878, 9.95, 9.815, 9.319, 11.223, 9.845],
+        [9.572, 9.648, 10.532, 10.365, 10.413, 10.431],
+        [12.142, 9.594, 9.488, 9.186, 10.616, 11.129],
+    ]
+)
+_L1_R_LOGFC = np.array([0.724333, 1.836333, -1.036667, -0.085333, 0.485667, -0.097667])
+_L1_R_P = np.array([0.376656, 0.014532, 0.134686, 0.902717, 0.444989, 0.904544])
+
+_Y2 = np.array(
+    [
+        [11.886, 11.16, 11.176, 10.651, 10.743, 10.543, 9.334, 10.232, 10.117, 10.219, 10.871, 10.224],
+        [12.679, 12.068, 12.289, 10.631, 8.543, 9.68, 9.53, 9.361, 9.725, 11.495, 9.134, 10.968],
+        [8.317, 9.665, 10.163, 10.586, 10.711, 10.793, 9.651, 9.538, 10.858, 9.809, 8.724, 8.867],
+        [9.081, 10.497, 10.142, 10.69, 9.573, 10.159, 10.626, 9.691, 10.457, 9.338, 9.637, 9.618],
+        [8.804, 10.487, 9.531, 10.012, 10.481, 10.447, 10.665, 9.902, 9.577, 9.92, 8.313, 8.553],
+        [8.677, 9.003, 10.4, 9.095, 9.622, 11.299, 9.644, 10.738, 9.066, 9.795, 9.05, 9.661],
+    ]
+)
+_L2_R_LOGFC = np.array([1.305333, 3.721, -2.197333, -0.961, -1.825333, -0.959333])
+_L2_R_P = np.array([0.066578, 0.000109, 0.007883, 0.194519, 0.024872, 0.263995])
+
+
+def _make_mdata(feature_by_sample: np.ndarray, obs: pd.DataFrame, modality: str = "protein") -> MuData:
+    sample_by_feature = feature_by_sample.T
+    var = pd.DataFrame(index=[f"P{i}" for i in range(feature_by_sample.shape[0])])
+    adata = AnnData(X=sample_by_feature, obs=obs.copy(), var=var)
+    return MuData({modality: adata})
+
+
+@pytest.fixture
+def level1_mdata() -> MuData:
+    obs = pd.DataFrame(
+        {"cond": ["A", "A", "A", "B", "B", "B"]},
+        index=[f"S{j}" for j in range(6)],
+    )
+    return _make_mdata(_Y1, obs)
+
+
+@pytest.fixture
+def level2_mdata() -> MuData:
+    obs = pd.DataFrame(
+        {
+            "treat": ["a"] * 6 + ["b"] * 6,
+            "geno": (["c"] * 3 + ["d"] * 3) * 2,
+        },
+        index=[f"T{j}" for j in range(12)],
+    )
+    return _make_mdata(_Y2, obs)
+
+
+# --- golden regression vs R limma -------------------------------------------------
+
+def test_main_effect_matches_r_limma(level1_mdata):
+    res = run_de(level1_mdata, "protein", category="cond", ctrl="A", expr="B", stat_method="limma")
+    np.testing.assert_allclose(res.log2fc, _L1_R_LOGFC, atol=1e-4)
+    np.testing.assert_allclose(res.p_value, _L1_R_P, atol=1e-4)
+    assert res.contrast_label == "B vs A"
+
+
+def test_interaction_matches_r_limma(level2_mdata):
+    # DiD (c-d)@a - (c-d)@b == R's (ac-ad)-(bc-bd)
+    res = run_de(
+        level2_mdata,
+        "protein",
+        category="geno",
+        ctrl="d",
+        expr="c",
+        stat_method="limma",
+        interaction="treat",
+        interaction_levels=["a", "b"],
+    )
+    np.testing.assert_allclose(res.log2fc, _L2_R_LOGFC, atol=1e-4)
+    np.testing.assert_allclose(res.p_value, _L2_R_P, atol=1e-4)
+    assert "interaction across treat" in res.contrast_label
+
+
+# --- contrast construction (the part msmu owns) -----------------------------------
+
+def test_build_contrast_main_effect_weights():
+    obs = pd.DataFrame({"cond": ["A", "A", "B", "B"]}, index=list("wxyz"))
+    contrast = build_contrast(obs, category="cond", ctrl="A", expr="B")
+    weights = dict(zip(contrast.cell_columns, contrast.weights))
+    assert weights == {"A": -1.0, "B": 1.0}
+
+
+def test_build_contrast_interaction_is_difference_of_differences():
+    obs = pd.DataFrame(
+        {"geno": ["c", "d", "c", "d"], "treat": ["a", "a", "b", "b"]},
+        index=list("wxyz"),
+    )
+    contrast = build_contrast(
+        obs, category="geno", ctrl="d", expr="c", interaction="treat", interaction_levels=["a", "b"]
+    )
+    weights = dict(zip(contrast.cell_columns, contrast.weights))
+    # (c@a - d@a) - (c@b - d@b)
+    assert weights == {"c|a": 1.0, "d|a": -1.0, "c|b": -1.0, "d|b": 1.0}
+
+
+# --- behaviour / guards -----------------------------------------------------------
+
+def test_sign_convention_positive_is_higher_in_expr(level1_mdata):
+    res = run_de(level1_mdata, "protein", category="cond", ctrl="A", expr="B", stat_method="limma")
+    # P1 is clearly up in B (injected); logFC must be positive
+    p1 = np.where(res.features == "P1")[0][0]
+    assert res.log2fc[p1] > 0
+    # swapping ctrl/expr flips the sign
+    swapped = run_de(level1_mdata, "protein", category="cond", ctrl="B", expr="A", stat_method="limma")
+    np.testing.assert_allclose(res.log2fc, -swapped.log2fc, atol=1e-9)
+
+
+def test_unknown_level_raises_with_available_listed(level1_mdata):
+    with pytest.raises(ValueError, match=r"not found in obs column 'cond'.*Available"):
+        run_de(level1_mdata, "protein", category="cond", ctrl="A", expr="ZZZ", stat_method="limma")
+
+
+def test_interaction_requires_exactly_two_levels():
+    obs = pd.DataFrame(
+        {"geno": ["c", "d", "c", "d", "c", "d"], "treat": ["a", "a", "b", "b", "e", "e"]},
+        index=[f"S{i}" for i in range(6)],
+    )
+    mdata = _make_mdata(np.random.default_rng(0).normal(10, 1, (4, 6)), obs)
+    with pytest.raises(ValueError, match="exactly 2 levels"):
+        run_de(mdata, "protein", category="geno", ctrl="d", expr="c", stat_method="limma", interaction="treat")
+
+
+def test_interaction_rejected_for_non_limma_method(level2_mdata):
+    with pytest.raises(ValueError, match="only supported with stat_method='limma'"):
+        run_de(
+            level2_mdata, "protein", category="geno", ctrl="d", expr="c",
+            stat_method="welch", interaction="treat", n_resamples=None,
+        )
+
+
+def test_limma_requires_explicit_expr(level1_mdata):
+    with pytest.raises(ValueError, match="requires an explicit 'expr'"):
+        run_de(level1_mdata, "protein", category="cond", ctrl="A", expr=None, stat_method="limma")
+
+
+def test_min_pct_filters_low_coverage_features():
+    obs = pd.DataFrame({"cond": ["A", "A", "A", "B", "B", "B"]}, index=[f"S{j}" for j in range(6)])
+    y = _Y1.copy()
+    y[0, 1:] = np.nan  # feature P0: only 1 non-missing across all samples
+    mdata = _make_mdata(y, obs)
+    res = run_de(mdata, "protein", category="cond", ctrl="A", expr="B", stat_method="limma", min_pct=0.5)
+    p0 = np.where(res.features == "P0")[0][0]
+    assert np.isnan(res.p_value[p0])
+    assert not np.isnan(res.p_value[np.where(res.features == "P1")[0][0]])
+
+
+def test_covariate_adjustment_runs(level2_mdata):
+    res = run_de(
+        level2_mdata, "protein", category="geno", ctrl="d", expr="c",
+        stat_method="limma", covariates=["treat"],
+    )
+    assert res.features.size == 6
+    assert np.isfinite(res.log2fc).any()
+
+
+def test_result_frame_has_expected_columns(level1_mdata):
+    res = run_de(level1_mdata, "protein", category="cond", ctrl="A", expr="B", stat_method="limma")
+    frame = res.to_df()
+    for column in ["features", "log2fc", "p_value", "q_value"]:
+        assert column in frame.columns
+    assert len(frame) == 6

--- a/tests/test_tools_pca_umap_dea.py
+++ b/tests/test_tools_pca_umap_dea.py
@@ -83,3 +83,37 @@ def test_run_de_invalid_fdr_raises(mdata):
             fdr="nope",
             n_resamples=None,
         )
+
+
+def test_run_de_simple_test_exposes_statistic(mdata):
+    res = run_de(
+        mdata,
+        modality="protein",
+        category="group",
+        ctrl="A",
+        expr="B",
+        stat_method="welch",
+        n_resamples=None,
+        fdr=False,
+    )
+    # the Welch t is now surfaced on DeaResult.statistic (was previously dropped)
+    assert res.statistic is not None
+    assert res.statistic.size == res.features.size
+    assert "statistic" in res.to_df().columns
+
+
+def test_run_de_permutation_exposes_observed_statistic(mdata):
+    res = run_de(
+        mdata,
+        modality="protein",
+        category="group",
+        ctrl="A",
+        expr="B",
+        stat_method="welch",
+        n_resamples=1000,
+        fdr="bh",
+    )
+    # permutation path surfaces the observed (Welch) statistic; p_value stays empirical
+    assert res.statistic is not None
+    assert res.statistic.size == res.features.size
+    assert "statistic" in res.to_df().columns


### PR DESCRIPTION
## Summary
Add `run_de(stat_method="limma")` — eBayes moderated-t (variance shrinkage across features) for power at small n. (BID-66)

## Changes
- **Level 1**: main effect `expr − ctrl`
- **Level 2**: interaction / difference-in-differences via `interaction` / `interaction_levels` — tests whether `expr − ctrl` differs across a second factor
- `covariates` for adjustment
- Engine: inmoose `lmFit` → `contrasts_fit` → `squeezeVar` (moderated t/p computed directly, sidestepping inmoose 0.9.1's lods bug); BH q-values
- `min_pct` estimable-feature filter keeps the per-gene design full rank, avoiding inmoose's NA singular-matrix crash
- Raw contrast coefficients are never exposed (domain-level args only); `DeaResult.contrast_label` describes the comparison

## Per-feature statistic (all DE methods)
- `DeaResult` gains a `statistic` field (also surfaced in `to_df()`); previously the Welch / moderated t was computed and then dropped
- Welch/Student/Wilcoxon → t / rank-sum, permutation → observed Welch t (p stays empirical), limma → moderated t; method-heterogeneous by design

## Testing
- Regression vs R limma 3.62 golden values (logFC / p match)
- `tests/test_tools_limma.py` (13) + `tests/test_tools_pca_umap_dea.py` (8) pass

## Out of scope
- F-test / ANOVA (≥3-level interaction), evidence-aware / soft-dropout, proDA
