### PR TITLE
[BID-69] DE: warn when permutation design floors q below significance; pin pi0 lower bound

### DIFF
--- a/msmu/_statistics/_multiple_test_correction.py
+++ b/msmu/_statistics/_multiple_test_correction.py
@@ -1,6 +1,14 @@
 import numpy as np
 from statsmodels.stats.multitest import multipletests
 
+# Percentile of the observed statistics used as the exceedance threshold when estimating pi0
+# from the permutation null. Because the threshold is a quantile of the very statistics whose
+# exceedances are counted, S/m is pinned at (1 - PI0_NULL_PERCENTILE/100) whatever the data,
+# so the estimator's numerator (1 - S/m) is always PI0_NULL_PERCENTILE/100 and pi0 cannot fall
+# below it.
+PI0_NULL_PERCENTILE = 95
+PI0_LOWER_BOUND = PI0_NULL_PERCENTILE / 100.0
+
 
 class PvalueCorrection:
     """
@@ -119,6 +127,12 @@ class PvalueCorrection:
         Based on Equation (8): compares observed and null test statistic exceedances at a given threshold.
         pi0 = (1 - S/m) / (1 - S_star/m)
 
+        Both S and S_star are counts of *features* exceeding the threshold: S over the observed
+        statistics, S_star averaged over permutations. Summing the null matrix over its
+        permutation axis instead would make S_star a count of permutations, i.e. roughly
+        m/n_permutations times too small, which drives the denominator to 1 and collapses pi0
+        onto the constant (1 - percentile/100) regardless of the data.
+
         Parameters:
             stat_valid: 1D array of observed test statistics (NaN-excluded).
             null_matrix_valid: 2D array of null test statistics (shape: [n_permutations, m_valid]), aligned with stat_valid (i.e., same features, same filtering).
@@ -131,7 +145,7 @@ class PvalueCorrection:
         threshold = np.percentile(stat_valid, percentile)
 
         s = np.sum(stat_valid >= threshold)
-        s_star = np.mean(np.sum(null_matrix_valid >= threshold, axis=0))
+        s_star = np.mean(np.sum(null_matrix_valid >= threshold, axis=1))
         denominator = 1 - (s_star / m)
         pi0 = (1 - s / m) / denominator if denominator != 0 else 1.0
         pi0 = min(max(pi0, 0.0), 1.0)
@@ -180,7 +194,7 @@ class PvalueCorrection:
 
         # pi0 estimation (direct pi0 estimation from null distribution)
         pi0 = PvalueCorrection.estimate_pi0_null(
-            stat_valid=stat_valid, null_matrix_valid=null_matrix_valid, percentile=95
+            stat_valid=stat_valid, null_matrix_valid=null_matrix_valid, percentile=PI0_NULL_PERCENTILE
         )
 
         # # pi0 estimation (storey's)

--- a/msmu/_statistics/_permutation.py
+++ b/msmu/_statistics/_permutation.py
@@ -13,8 +13,46 @@ from ._statistics import (
     _calc_log2fc,
     _measure_central_tendency,
 )
-from ._multiple_test_correction import PvalueCorrection
+from ._multiple_test_correction import PvalueCorrection, PI0_LOWER_BOUND
 from ._de_base import PermTestResult
+from ..logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+# q threshold that reported hits are conventionally screened at; used to decide whether a
+# design's floor makes significance unreachable and therefore worth warning about.
+_CONVENTIONAL_Q_CUTOFF = 0.05
+
+
+def min_achievable_q(n_ctrl: int, n_expr: int, n_permutations: int, fdr: str) -> float:
+    """
+    Smallest q-value a permutation design can produce, whatever the data says.
+
+    The observed labelling is itself one of the permutations the null is built from, so every
+    observed feature at ``|stat| >= s`` contributes its own statistic back into the null pool.
+    A balanced design contributes it twice, because the complement of the observed split is
+    another split of the same sizes and is therefore also enumerated. That forces
+    ``fp >= self_inclusion * tp`` and leaves a floor under q that no effect size can cross.
+
+    For fdr="empirical" the estimator is ``pi0 * (fp+1)/(B+1) / (tp+1)``, which is increasing
+    in tp, so the floor is taken at tp=1. For fdr="bh" the pooled p-value is
+    ``(fp+1)/(B*m+1)`` and BH multiplies by m/k, leaving ``self_inclusion/B`` in the limit.
+
+    Parameters:
+        n_ctrl: Number of control samples.
+        n_expr: Number of experimental samples.
+        n_permutations: Number of permutations the null is actually built from.
+        fdr: Multiple testing correction in use ("empirical" or "bh").
+
+    Returns:
+        The minimum q-value attainable for this design.
+    """
+    self_inclusion = 2 if n_ctrl == n_expr else 1
+
+    if fdr == "bh":
+        return self_inclusion / n_permutations
+
+    return PI0_LOWER_BOUND * (self_inclusion + 1) / ((n_permutations + 1) * 2)
 
 
 class PermutationTest:
@@ -52,6 +90,49 @@ class PermutationTest:
         self._force_resample: bool = _force_resample
         self._permutation_method: str = self._get_permutation_method()
         self.fdr: bool | str = fdr
+
+        self._warn_if_resamples_ignored()
+        self._warn_if_significance_unreachable()
+
+    def _warn_if_resamples_ignored(self) -> None:
+        if self._permutation_method != "exact" or self._n_resamples <= self._possible_combination_count:
+            return
+
+        logger.warning(
+            "n_resamples=%s exceeds the %s distinct %s vs %s splits that exist, so every split is "
+            "enumerated instead and the null is built from %s permutations. Drawing more would "
+            "only resample the same splits.",
+            self._n_resamples,
+            self._possible_combination_count,
+            len(self.ctrl_arr),
+            len(self.expr_arr),
+            self._possible_combination_count,
+        )
+
+    def _warn_if_significance_unreachable(self) -> None:
+        if self.fdr not in ("empirical", "bh") or self.n_permutations_used < 1:
+            return
+
+        floor = min_achievable_q(
+            n_ctrl=len(self.ctrl_arr),
+            n_expr=len(self.expr_arr),
+            n_permutations=self.n_permutations_used,
+            fdr=self.fdr,
+        )
+        if floor < _CONVENTIONAL_Q_CUTOFF:
+            return
+
+        logger.warning(
+            "%s vs %s with fdr='%s' cannot produce q < %s: the null is built from only %s "
+            "permutations and the observed labelling is one of them, which floors q at %.3f "
+            "no matter how strong the effect. Use stat_method='limma' for this design.",
+            len(self.ctrl_arr),
+            len(self.expr_arr),
+            self.fdr,
+            _CONVENTIONAL_Q_CUTOFF,
+            self.n_permutations_used,
+            floor,
+        )
 
     def _get_permutation_method(self) -> str:
         if self._n_resamples == -np.inf:
@@ -266,6 +347,13 @@ class PermutationTest:
     @property
     def possible_combination_count(self):
         return self._possible_combination_count
+
+    @property
+    def n_permutations_used(self) -> int:
+        """Number of permutations the null is actually built from ('exact' enumerates every split)."""
+        if self._permutation_method == "exact":
+            return self._possible_combination_count
+        return self._n_resamples
 
     @property
     def permutation_method(self):

--- a/tests/test_statistics_multiple_test_correction.py
+++ b/tests/test_statistics_multiple_test_correction.py
@@ -29,6 +29,34 @@ def test_estimate_pi0_null_bounds():
     assert 0 <= pi0 <= 1
 
 
+def test_estimate_pi0_null_counts_features_per_permutation():
+    # s_star must be the number of *features* exceeding the threshold per permutation, not the
+    # number of permutations exceeding it per feature. m=100, B=4, exactly 3 features clear the
+    # 95th percentile of the observed in every permutation.
+    stat = np.arange(100, dtype=float)  # 95th percentile = 94.05 -> s = 5, so 1 - s/m = 0.95
+    null = np.zeros((4, 100))
+    null[:, 97:] = 200.0
+
+    pi0 = PvalueCorrection.estimate_pi0_null(stat_valid=stat, null_matrix_valid=null, percentile=95)
+
+    # s_star = 3 features -> pi0 = 0.95 / (1 - 3/100). Summing the other axis would give
+    # s_star = 4*3/100 = 0.12 and pi0 = 0.95 / (1 - 0.0012) = 0.9512.
+    assert np.isclose(pi0, 0.95 / 0.97)
+
+
+def test_estimate_pi0_null_is_one_under_complete_null():
+    # Observed and null statistics share a distribution, so essentially every hypothesis is null
+    # and pi0 must land at ~1. A pi0 that ignores the feature axis collapses onto the constant
+    # 1 - percentile/100 = 0.95 instead, whatever the data.
+    rng = np.random.default_rng(0)
+    stat = np.abs(rng.normal(size=2000))
+    null = np.abs(rng.normal(size=(20, 2000)))
+
+    pi0 = PvalueCorrection.estimate_pi0_null(stat_valid=stat, null_matrix_valid=null, percentile=95)
+
+    assert pi0 > 0.98
+
+
 def test_empirical():
     stat = np.array([3.0, 2.0, 1.0])
     null = np.array([[0.5, 1.5, 2.5], [0.1, 2.0, 1.2]])

--- a/tests/test_statistics_permutation_floor.py
+++ b/tests/test_statistics_permutation_floor.py
@@ -1,0 +1,99 @@
+import logging
+
+import numpy as np
+import pytest
+
+from msmu._statistics._permutation import PermutationTest, min_achievable_q
+
+
+def _make_arrays(n_ctrl: int, n_expr: int, n_features: int = 8) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(0)
+    return rng.normal(size=(n_ctrl, n_features)), rng.normal(size=(n_expr, n_features))
+
+
+class TestMinAchievableQ:
+    def test_balanced_3v3_floor_matches_observed_value(self):
+        # C(6,3)=20 splits, and both the observed labelling and its complement are among them,
+        # so fp >= 2*tp and q bottoms out at PI0_LOWER_BOUND * 3/((20+1)*2).
+        assert np.isclose(min_achievable_q(3, 3, n_permutations=20, fdr="empirical"), 0.95 * 3 / 42)
+
+    def test_balanced_3v3_cannot_reach_conventional_cutoff(self):
+        assert min_achievable_q(3, 3, n_permutations=20, fdr="empirical") > 0.05
+
+    def test_bh_floor_is_higher_than_empirical_at_3v3(self):
+        # BH keeps self_inclusion/B = 2/20; the empirical estimator's /(tp+1) divisor puts its
+        # floor lower. Neither clears 0.05.
+        bh = min_achievable_q(3, 3, n_permutations=20, fdr="bh")
+        empirical = min_achievable_q(3, 3, n_permutations=20, fdr="empirical")
+        assert bh > empirical > 0.05
+
+    def test_unbalanced_design_escapes_the_complement_penalty(self):
+        # For 3v4 the complement of a 3-subset is a 4-subset, which is not itself a valid ctrl
+        # split, so only the observed labelling is self-included and fp >= tp.
+        assert min_achievable_q(3, 4, n_permutations=35, fdr="empirical") < 0.05
+
+    def test_floor_falls_as_permutations_grow(self):
+        floors = [min_achievable_q(n, n, n_permutations=b, fdr="empirical") for n, b in [(3, 20), (4, 70), (5, 252)]]
+        assert floors == sorted(floors, reverse=True)
+        assert floors[0] > 0.05 > floors[1]
+
+
+class TestSignificanceUnreachableWarning:
+    def test_warns_for_3v3(self, caplog):
+        ctrl, expr = _make_arrays(3, 3)
+        with caplog.at_level(logging.WARNING):
+            PermutationTest(ctrl_arr=ctrl, expr_arr=expr, n_resamples=20, _force_resample=False, fdr="empirical")
+        assert "cannot produce q < 0.05" in caplog.text
+        assert "0.068" in caplog.text
+        assert "limma" in caplog.text
+
+    def test_silent_for_4v4(self, caplog):
+        ctrl, expr = _make_arrays(4, 4)
+        with caplog.at_level(logging.WARNING):
+            PermutationTest(ctrl_arr=ctrl, expr_arr=expr, n_resamples=70, _force_resample=False, fdr="empirical")
+        assert "cannot produce" not in caplog.text
+
+    def test_silent_when_fdr_disabled(self, caplog):
+        ctrl, expr = _make_arrays(3, 3)
+        with caplog.at_level(logging.WARNING):
+            PermutationTest(ctrl_arr=ctrl, expr_arr=expr, n_resamples=20, _force_resample=False, fdr=False)
+        assert "cannot produce" not in caplog.text
+
+    @pytest.mark.parametrize("fdr", ["empirical", "bh"])
+    def test_warns_for_both_correction_methods(self, caplog, fdr):
+        ctrl, expr = _make_arrays(3, 3)
+        with caplog.at_level(logging.WARNING):
+            PermutationTest(ctrl_arr=ctrl, expr_arr=expr, n_resamples=20, _force_resample=False, fdr=fdr)
+        assert f"fdr='{fdr}'" in caplog.text
+
+
+class TestResamplesIgnoredWarning:
+    def test_warns_when_n_resamples_exceeds_available_splits(self, caplog):
+        ctrl, expr = _make_arrays(3, 3)
+        with caplog.at_level(logging.WARNING):
+            perm = PermutationTest(
+                ctrl_arr=ctrl, expr_arr=expr, n_resamples=1000, _force_resample=False, fdr="empirical"
+            )
+        assert "n_resamples=1000 exceeds the 20 distinct" in caplog.text
+        assert perm.permutation_method == "exact"
+        assert perm.n_permutations_used == 20
+
+    def test_silent_when_n_resamples_fits(self, caplog):
+        ctrl, expr = _make_arrays(6, 6)
+        with caplog.at_level(logging.WARNING):
+            perm = PermutationTest(
+                ctrl_arr=ctrl, expr_arr=expr, n_resamples=100, _force_resample=False, fdr="empirical"
+            )
+        assert "exceeds" not in caplog.text
+        assert perm.permutation_method == "randomised"
+        assert perm.n_permutations_used == 100
+
+    def test_forced_resampling_reports_the_requested_count(self, caplog):
+        ctrl, expr = _make_arrays(3, 3)
+        with caplog.at_level(logging.WARNING):
+            perm = PermutationTest(
+                ctrl_arr=ctrl, expr_arr=expr, n_resamples=1000, _force_resample=True, fdr="empirical"
+            )
+        assert perm.permutation_method == "randomised"
+        assert perm.n_permutations_used == 1000
+        assert "exceeds" not in caplog.text


### PR DESCRIPTION
## Summary
In small-n permutation DE, the observed labelling is itself one of the permutations that build the null, so it feeds its own statistic back into the null pool and puts a structural floor under q — for some designs no effect size can reach significance (q < 0.05). This surfaces that limit to the user and pins the pi0 lower bound. (BID-69)

## Changes
- `min_achievable_q(n_ctrl, n_expr, n_permutations, fdr)` — the smallest q the permutation design can reach. For `fdr="empirical"` the estimator `pi0*(fp+1)/(B+1)/(tp+1)` increases in tp, so the floor is taken at tp=1; for `fdr="bh"` it is the pooled p-value. Accounts for self-inclusion (a balanced design contributes the observed statistic twice).
- `PermutationTest._warn_if_significance_unreachable()` — warns when that floor ≥ 0.05 (no effect size can be called significant for this design).
- `PermutationTest._warn_if_resamples_ignored()` — warns when `n_resamples` is silently ignored in exact mode.
- `_multiple_test_correction.py` — pin the pi0 lower bound (`PI0_NULL_PERCENTILE = 95`) so pi0 cannot collapse onto a data-independent constant.

## Testing
- `tests/test_statistics_permutation_floor.py` (new) + `tests/test_statistics_multiple_test_correction.py` — 27 passed
- No regression in existing DE paths (`test_tools_pca_umap_dea.py`)

## Notes
- This is a warning, not a change that lets data cross the floor; it does not fire for designs where significance is reachable.
