### PR TITLE
chore: gitignore scratch/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ msmu/_version.py
 
 # uv
 uv.lock
+
+# scratch / local analysis outputs
+scratch/


### PR DESCRIPTION
Ignore the untracked `scratch/` directory (local EDA / analysis scripts that should not be versioned). No tracked files are affected.
