### PR TITLE
fix: stop median polish collapsing majority-empty protein groups to ~0 [BID-77]

### DIFF
--- a/msmu/_preprocessing/_summarisation.py
+++ b/msmu/_preprocessing/_summarisation.py
@@ -130,8 +130,12 @@ def _median_polish(feature_by_sample_matrix: np.ndarray) -> np.ndarray:
     IMPORTANT: this is an *additive* model, so it must be applied to log-space
     intensities (e.g. log2). Applying it to linear intensities is not meaningful.
 
-    NaN handling: missing values are ignored via ``nanmedian``. A sample column with no
-    observed values across every feature yields ``NaN`` (there is nothing to summarise).
+    NaN handling: fully-missing features (all-NaN rows) are dropped before polishing --
+    they carry no information, and keeping them would bias the row-effect alignment median
+    that recovers the overall protein level toward zero (collapsing groups whose features
+    are mostly all-NaN, e.g. proteins quantified by a few unique peptides among many masked
+    shared ones). Remaining missing values are ignored via ``nanmedian``. A sample column
+    with no observed values across every feature yields ``NaN`` (there is nothing to summarise).
 
     Args:
         feature_by_sample_matrix (np.ndarray): 2D array of log-space intensities with
@@ -140,13 +144,26 @@ def _median_polish(feature_by_sample_matrix: np.ndarray) -> np.ndarray:
     Returns:
         np.ndarray: 1D array of length ``n_samples`` with the per-sample rollup estimate.
     """
-    residual_matrix = np.array(feature_by_sample_matrix, dtype=float, copy=True)
+    input_matrix = np.asarray(feature_by_sample_matrix, dtype=float)
 
-    if residual_matrix.ndim != 2:
+    if input_matrix.ndim != 2:
         raise ValueError("median polish expects a 2D feature-by-sample matrix.")
 
-    number_of_features, number_of_samples = residual_matrix.shape
-    fully_missing_sample_mask = np.all(np.isnan(residual_matrix), axis=0)
+    number_of_samples = input_matrix.shape[1]
+    fully_missing_sample_mask = np.all(np.isnan(input_matrix), axis=0)
+
+    # Drop fully-missing features before polishing (symmetric with ``_directlfq_rollup``). An
+    # all-NaN row carries no information, yet ``nanmedian`` still yields a placeholder row effect
+    # that, folded back through the row-effect alignment median, drags ``overall`` -- and therefore
+    # every sample estimate -- toward zero. When such rows are the majority of a protein group
+    # (e.g. a few unique peptides among many masked shared ones) they collapse the whole protein
+    # to ~0. Boolean indexing returns a fresh writable copy, so the sweeps mutate in place safely.
+    observed_feature_mask = ~np.all(np.isnan(input_matrix), axis=1)
+    if not observed_feature_mask.any():
+        return np.full(number_of_samples, np.nan, dtype=float)
+    residual_matrix = input_matrix[observed_feature_mask]
+
+    number_of_features = residual_matrix.shape[0]
 
     overall_effect: float = 0.0
     row_effects = np.zeros(number_of_features, dtype=float)
@@ -154,7 +171,8 @@ def _median_polish(feature_by_sample_matrix: np.ndarray) -> np.ndarray:
     previous_residual_sum: float = np.inf
 
     with warnings.catch_warnings():
-        # nanmedian legitimately hits all-NaN rows/columns for fully-missing features/samples.
+        # nanmedian legitimately hits all-NaN columns for fully-missing samples (all-NaN rows
+        # were dropped above), so silence the resulting empty-slice warning.
         warnings.filterwarnings(action="ignore", message="All-NaN slice encountered")
         for iteration in range(MEDIAN_POLISH_MAX_ITERATIONS):
             # Row sweep: remove the median of each feature (row) across samples.

--- a/tests/test_preprocessing_summarisation.py
+++ b/tests/test_preprocessing_summarisation.py
@@ -117,6 +117,46 @@ def test_median_polish_fully_missing_sample_is_nan():
     assert not np.isnan(estimates[2])
 
 
+def test_median_polish_ignores_fully_missing_features():
+    # Regression: all-NaN peptide rows (e.g. shared peptides masked out during the protein
+    # rollup) must not drag the protein level toward zero. The estimate has to match the same
+    # matrix with those empty rows removed and stay on the input's log2 scale, not collapse to ~0.
+    signal = np.array([16.64, 16.73, 16.55, 16.55, 15.99, 16.53])
+    empty = np.full_like(signal, np.nan)
+    with_empty_rows = np.vstack([signal, empty, empty, empty])
+
+    estimates = _median_polish(with_empty_rows)
+
+    np.testing.assert_allclose(estimates, _median_polish(signal[None, :]), atol=1e-8)
+    np.testing.assert_allclose(estimates, signal, atol=1e-8)
+    assert np.nanmedian(estimates) > 5.0  # not collapsed toward zero
+
+
+def test_median_polish_level_survives_majority_missing_features():
+    # A few observed peptides among many all-NaN rows (a large protein group quantified by only
+    # a handful of unique peptides). The recovered level must track the ~21 observations, not 0.
+    observed = np.array(
+        [
+            [20.8, 20.9, 20.8, 20.8, 19.0, 20.8],
+            [21.1, 21.3, 21.1, 21.0, 17.8, 21.1],
+            [21.7, 21.7, 21.5, 21.7, 20.0, 21.4],
+        ]
+    )
+    padded = np.full((50, observed.shape[1]), np.nan)
+    padded[[10, 25, 40], :] = observed
+
+    estimates = _median_polish(padded)
+
+    np.testing.assert_allclose(estimates, _median_polish(observed), atol=1e-8)
+    assert np.nanmin(estimates) > 15.0  # on the ~21 log2 scale, not collapsed toward zero
+
+
+def test_median_polish_all_missing_matrix_is_all_nan():
+    estimates = _median_polish(np.full((3, 4), np.nan))
+    assert estimates.shape == (4,)
+    assert np.all(np.isnan(estimates))
+
+
 def test_aggregator_quantification_median_polish():
     id_df = pd.DataFrame(
         {


### PR DESCRIPTION
## Problem
`to_protein(agg_method="median_polish")` produced protein abundances near `0` instead of the input log2 scale (~16–21). Reported symptom: "final protein values come out as 0.0x, the scale isn't preserved."

## Root cause
`_median_polish` returns `overall + col_effect[sample]`, and the protein's level is recovered into `overall` via `nanmedian(row_effects)`. A fully-missing (all-NaN) peptide row has its row median coerced to `0` by `nan_to_num`, so it enters `row_effects` as a spurious `0`. Once such rows are the **majority** of a protein group, that median collapses to ~0 and drags every per-sample estimate down with it — **exactly halved** at 50% empty rows, **~0** beyond.

All-NaN rows arise because `to_protein` masks shared peptides (`peptide_type_eq_unique`) to NaN instead of dropping them, so protein groups quantified by a few unique peptides among many shared ones become mostly-empty matrices. On a real TMT6 dataset this hit **57.9% of protein groups (5,736 / 9,913)** and **100% of groups with ≥7 peptides**.

## Fix
Drop fully-missing feature rows before polishing — symmetric with `_directlfq_rollup`, which already does exactly this (so directlfq was never affected). The rollup returns per-sample estimates, so removing rows does not change which samples are reported. Behaviour is unchanged on data with no all-NaN rows.

## Verification
- Unit tests: **21/21** in `test_preprocessing_summarisation.py`, incl. 3 new regression tests (ignores fully-missing features; level survives majority-missing features; all-missing matrix → all-NaN).
- Real data (SNU_Cell_TMT6): protein `.X` median **0.068 → 18.27**, range restored to **11.2–25.0**; the near-zero mode is gone.

## Files
- `msmu/_preprocessing/_summarisation.py` — drop all-NaN rows in `_median_polish`
- `tests/test_preprocessing_summarisation.py` — 3 regression tests

Ticket: BID-77
