### PR TITLE
[BID-112] corr() writes its result back into the returned MuData

### DIFF
--- a/msmu/_tools/_correlation.py
+++ b/msmu/_tools/_correlation.py
@@ -5,7 +5,7 @@ Module for correlation plots in MuData.
 from typing import Literal
 from mudata import MuData
 
-from .._utils._mudata import get_anndata_mod
+from .._utils._mudata import get_anndata_mod, get_mudata_mod_as_mutable
 from .._core._blockdiag import to_dense_df
 from .._core._provenance import uns_logger
 
@@ -27,7 +27,8 @@ def corr(
         method: Correlation method to use: "pearson", "spearman", or "kendall". Defaults to "pearson".
 
     Returns:
-        DataFrame representing the correlation matrix.
+        The input MuData (copied) with the correlation matrix stored in the modality's
+        ``obsp["X_corr"]``.
     """
     mdata = mdata.copy()
     adata = get_anndata_mod(mdata, modality).copy()
@@ -41,5 +42,8 @@ def corr(
     corr_matrix = data.T.corr(method=method)
 
     adata.obsp["X_corr"] = corr_matrix.values
+    # Write the modified copy back into the returned mdata: previously obsp was set on a detached
+    # .copy() while the untouched mdata was returned, so every corr() call silently discarded it.
+    get_mudata_mod_as_mutable(mdata)[modality] = adata
 
     return mdata

--- a/tests/test_tools_correlation.py
+++ b/tests/test_tools_correlation.py
@@ -1,0 +1,20 @@
+"""``corr`` must attach its result to the RETURNED MuData.
+
+Regression for a bug where ``corr`` computed the correlation, wrote it to ``obsp['X_corr']`` on a
+detached ``.copy()`` of the modality, and then returned the untouched ``mdata`` -- so the result was
+silently discarded on every call.
+"""
+
+import numpy as np
+
+from msmu._tools._correlation import corr
+
+
+def test_corr_attaches_result_to_returned_mdata(simple_mdata):
+    out = corr(simple_mdata, "psm")
+
+    assert "X_corr" in out["psm"].obsp, "corr() did not attach obsp['X_corr'] to the returned mdata"
+    n_obs = out["psm"].n_obs
+    assert out["psm"].obsp["X_corr"].shape == (n_obs, n_obs)
+    # the correlation was actually computed, not left as an empty / all-NaN placeholder
+    assert not np.isnan(out["psm"].obsp["X_corr"]).all()


### PR DESCRIPTION
## Summary

`corr()` computed the correlation, wrote it to `obsp['X_corr']` on a **detached `.copy()`** of the modality, then returned the untouched `mdata` — so every call silently discarded its result (the returned MuData was effectively the input, minus the correlation).

## Fix
- Write the modified modality back via `get_mudata_mod_as_mutable` before returning.
- Fix the docstring (it returns a MuData, not a DataFrame).

## Test
- Regression test asserting `obsp['X_corr']` is attached to the returned mdata's modality.

Pre-existing bug (present on dev; surfaced by the BID-79 ultrareview), independent of BID-79. Full non-notebook suite passing, ruff clean.