### PR TITLE
fix(plotting): apply msmu template to plot output without global side effects

### DIFF
--- a/msmu/_plotting/_plots_statistics.py
+++ b/msmu/_plotting/_plots_statistics.py
@@ -5,6 +5,7 @@ import pandas as pd
 import plotly.graph_objects as go
 
 from ._ptypes import PlotScatter
+from ._utils import apply_msmu_template
 
 
 def plot_volcano(
@@ -98,4 +99,6 @@ def plot_volcano(
                 arrowwidth=1,
             )
 
-    return fig
+    # plot_volcano takes a results frame (no PlotContext), so it does not pass through
+    # finalize_figure; apply the msmu house style explicitly.
+    return apply_msmu_template(fig)

--- a/msmu/_plotting/_utils.py
+++ b/msmu/_plotting/_utils.py
@@ -508,6 +508,20 @@ def ensure_msmu_templates_registered() -> None:
         add_msmu_pastel_template()
 
 
+def apply_msmu_template(fig: go.Figure, template: str | None = None) -> go.Figure:
+    """Register the msmu templates if needed and apply one to ``fig`` (msmu by default).
+
+    Every public plot function routes its output through this helper so figures carry the
+    msmu house style per-figure, without relying on the global ``pio.templates.default``
+    (i.e. without any import-time side effect). Functions that build a figure outside the
+    :func:`finalize_figure` path — e.g. :func:`plot_volcano`, which takes a results frame
+    rather than a MuData and therefore has no :class:`PlotContext` — call this directly.
+    """
+    ensure_msmu_templates_registered()
+    fig.update_layout(template=resolve_template_key(template or DEFAULT_TEMPLATE))
+    return fig
+
+
 def finalize_figure(
     fig: go.Figure,
     *,
@@ -516,13 +530,13 @@ def finalize_figure(
     apply_color: bool = False,
 ) -> go.Figure:
     """Apply the msmu template, shared layout overrides, and optional categorical coloring."""
-    ensure_msmu_templates_registered()
-
     # msmu styles every figure it produces. The template is applied per-figure (not via the
     # global default) so import stays side-effect-free; an explicit template in layout_kwargs
     # still wins.
-    if "template" not in layout_kwargs:
-        fig.update_layout(template=resolve_template_key(context.template or DEFAULT_TEMPLATE))
+    if "template" in layout_kwargs:
+        ensure_msmu_templates_registered()  # so an explicit "msmu"/"msmu_pastel" still resolves
+    else:
+        fig = apply_msmu_template(fig, context.template)
 
     fig = apply_layout_overrides(fig, layout_kwargs)
 

--- a/msmu/_plotting/_utils.py
+++ b/msmu/_plotting/_utils.py
@@ -12,6 +12,7 @@ import plotly.graph_objects as go
 import plotly.io as pio
 
 from ..logging_utils import get_logger
+from ._template import DEFAULT_TEMPLATE, add_msmu_template, add_msmu_pastel_template
 
 _FALLBACK_COLUMN = "__obs_idx__"
 _DEFAULT_OBS_PRIORITY = (
@@ -494,6 +495,19 @@ def get_bin_info(data: pd.DataFrame | pd.Series | np.ndarray, bins: int) -> BinI
     )
 
 
+def ensure_msmu_templates_registered() -> None:
+    """Register the msmu Plotly templates on first use, without changing the global default.
+
+    Registering (rather than activating via ``pio.templates.default``) lets a per-figure
+    ``template="msmu"`` resolve to the house style while keeping ``import msmu`` free of any
+    global Plotly side effect. Users who want msmu as the session-wide default can still opt
+    in explicitly with :func:`msmu.pl.set_templates`.
+    """
+    if DEFAULT_TEMPLATE not in pio.templates:
+        add_msmu_template()
+        add_msmu_pastel_template()
+
+
 def finalize_figure(
     fig: go.Figure,
     *,
@@ -501,7 +515,15 @@ def finalize_figure(
     layout_kwargs: dict,
     apply_color: bool = False,
 ) -> go.Figure:
-    """Apply shared layout overrides and optional categorical coloring."""
+    """Apply the msmu template, shared layout overrides, and optional categorical coloring."""
+    ensure_msmu_templates_registered()
+
+    # msmu styles every figure it produces. The template is applied per-figure (not via the
+    # global default) so import stays side-effect-free; an explicit template in layout_kwargs
+    # still wins.
+    if "template" not in layout_kwargs:
+        fig.update_layout(template=resolve_template_key(context.template or DEFAULT_TEMPLATE))
+
     fig = apply_layout_overrides(fig, layout_kwargs)
 
     if apply_color and context.groupby is not None and context.template is not None:

--- a/tests/test_plotting_plots.py
+++ b/tests/test_plotting_plots.py
@@ -11,6 +11,7 @@ from msmu._plotting._plots import (
     plot_umap,
     plot_upset,
     plot_var,
+    plot_volcano,
 )
 
 
@@ -97,24 +98,48 @@ def test_plot_missingness_builds_step_plot(mdata):
 
 
 def test_plot_functions_apply_msmu_template_without_set_templates(mdata):
-    """Regression (BID-115): pl.plot_* output carries the msmu house style even when the
-    global Plotly default was never switched to msmu via set_templates()."""
+    """Regression (BID-115): EVERY public pl.plot_* output carries the msmu house style even
+    when the global Plotly default was never switched to msmu via set_templates().
+
+    Covers all public plot functions — including plot_volcano, which takes a results frame
+    (no PlotContext) and does not route through finalize_figure — so a future function that
+    forgets the msmu template is caught here.
+    """
     import plotly.io as pio
+
+    de_results = pd.DataFrame(
+        {
+            "features": ["p1", "p2", "p3", "p4", "p5", "p6"],
+            "log2fc": [2.0, -2.2, 0.1, 1.6, -1.9, 0.0],
+            "p_value": [0.001, 0.002, 0.5, 0.01, 0.02, 0.9],
+        }
+    )
+    builders = {
+        "plot_id": lambda: plot_id(mdata, modality="protein", groupby="group", obs_column="sample"),
+        "plot_intensity": lambda: plot_intensity(
+            mdata, modality="psm", groupby="group", ptype="box", obs_column="sample"
+        ),
+        "plot_missingness": lambda: plot_missingness(mdata, modality="psm", obs_column="sample"),
+        "plot_correlation": lambda: plot_correlation(
+            mdata, modality="protein", groupby="group", obs_column="sample"
+        ),
+        "plot_var": lambda: plot_var(
+            mdata, modality="psm", groupby="group", var_column="class", obs_column="sample"
+        ),
+        "plot_pca": lambda: plot_pca(mdata, modality="protein", groupby="group", obs_column="sample"),
+        "plot_umap": lambda: plot_umap(mdata, modality="protein", groupby="group", obs_column="sample"),
+        "plot_upset": lambda: plot_upset(mdata, modality="protein", groupby="group", obs_column="sample"),
+        "plot_volcano": lambda: plot_volcano(de_results, ctrl="A", expr="B", log2fc_threshold=1.0),
+    }
 
     original_default = pio.templates.default
     pio.templates.default = "plotly"  # a session that never opted into set_templates()
     try:
-        # obs_only path — no template threaded through the context
-        step = plot_missingness(mdata, modality="psm", obs_column="sample")
-        # grouped path — template threaded through the context
-        hist = plot_intensity(
-            mdata, modality="psm", groupby="group", ptype="hist", obs_column="sample", bins=2
-        )
-
-        for fig in (step, hist):
+        for name, build in builders.items():
+            fig = build()
             # per-figure template application, not the global default
-            assert fig.layout.template.layout.plot_bgcolor == "white"
-            assert fig.layout.template.layout.plot_bgcolor != "#E5ECF6"
+            bg = fig.layout.template.layout.plot_bgcolor
+            assert bg == "white", f"{name}: expected msmu template (white bg), got {bg!r}"
     finally:
         pio.templates.default = original_default
 

--- a/tests/test_plotting_plots.py
+++ b/tests/test_plotting_plots.py
@@ -96,6 +96,29 @@ def test_plot_missingness_builds_step_plot(mdata):
     assert fig.data[0].name == "Missingness"
 
 
+def test_plot_functions_apply_msmu_template_without_set_templates(mdata):
+    """Regression (BID-115): pl.plot_* output carries the msmu house style even when the
+    global Plotly default was never switched to msmu via set_templates()."""
+    import plotly.io as pio
+
+    original_default = pio.templates.default
+    pio.templates.default = "plotly"  # a session that never opted into set_templates()
+    try:
+        # obs_only path — no template threaded through the context
+        step = plot_missingness(mdata, modality="psm", obs_column="sample")
+        # grouped path — template threaded through the context
+        hist = plot_intensity(
+            mdata, modality="psm", groupby="group", ptype="hist", obs_column="sample", bins=2
+        )
+
+        for fig in (step, hist):
+            # per-figure template application, not the global default
+            assert fig.layout.template.layout.plot_bgcolor == "white"
+            assert fig.layout.template.layout.plot_bgcolor != "#E5ECF6"
+    finally:
+        pio.templates.default = original_default
+
+
 def test_plot_pca_and_umap(mdata):
     pca_fig = plot_pca(mdata, modality="protein", groupby="group", obs_column="sample")
     assert len(pca_fig.data) == 2


### PR DESCRIPTION
## Summary

`msmu.pl.plot_*()` output had lost the msmu house style (white background, no gridlines, Tableau-10 colorway) and rendered with Plotly's default template (grey-blue background, gridlines).

Root cause: the `msmu/__init__.py` auto-call to `set_templates()` was dropped in `8436ed8`, and the plotting refactor stopped threading `template="msmu"` into each figure. `finalize_figure` never applied a template, and the `"msmu"` template was never registered at runtime, so `resolve_template_key` always fell back to `"plotly"`. On `main` this was masked because `import msmu` set `pio.templates.default = "msmu"` globally.

## Fix

The msmu template is applied **per-figure** (not via the global `pio.templates.default`), keeping `import msmu` side-effect-free:

- A shared helper `apply_msmu_template(fig)` registers the msmu templates (idempotent) and applies one to a figure.
- `finalize_figure` routes every context-based plot through it.
- `plot_volcano` — which takes a DE-results DataFrame rather than a MuData, so it has no `PlotContext` and does **not** pass through `finalize_figure` — calls the helper directly. (It keeps its own width/height and UP/DOWN marker colours; only the template/background changes.)
- `import msmu` stays side-effect-free — the guard test `test_import_msmu_preserves_plotly_template_state` is unaffected.
- `set_templates()` remains an explicit opt-in for a session-wide default.

## Tests

- New regression test `test_plot_functions_apply_msmu_template_without_set_templates` exercises **all nine public plot functions** (including `plot_volcano`) and asserts each carries the msmu template (white background) when the global default was never switched to msmu — so a plot that bypasses `finalize_figure` cannot regress unnoticed.
- Full plotting suite (85 tests) passes; `ruff` clean.

Ticket: BID-115
