### PR TITLE
feat(preprocessing): implement total-sum normalisation (BID-117)

### DIFF
--- a/docs/how-it-works/normalization.md
+++ b/docs/how-it-works/normalization.md
@@ -17,13 +17,15 @@ mdata = mm.pp.log2_transform(
 
 ## `normalize()` (or `normalise()`)
 
-The `normalize()` function offers multiple normalization methods, including median (`median`) and quantile (`quantile`) normalization. Users can select the method that best suits their data and experimental design. For fractionated TMT data, setting the `fraction` argument to `True` ensures that normalization is performed within each fraction separately.
+The `normalize()` function offers multiple normalization methods, including median (`median`), quantile (`quantile`), and total-intensity / constant-sum (`total_sum`) normalization. Users can select the method that best suits their data and experimental design. For fractionated TMT data, setting the `fraction` argument to `True` ensures that normalization is performed within each fraction separately.
+
+`total_sum` rescales each sample so that its summed intensity equals the median of the per-sample totals, correcting sample-to-sample loading differences while leaving within-sample feature ratios unchanged. Because summing log values is meaningless, it computes each sample's total on the linear scale internally; like the other methods it assumes log2-transformed input.
 
 ```python
 mdata = mm.pp.normalize(
     mdata,
     modality="psm",           # or "peptide", "protein"
-    method="median",          # options: "median", "quantile", default "median"
+    method="median",          # options: "median", "quantile", "total_sum"; default "median"
     fraction=False            # whether data is fractionated
 )
 ```

--- a/msmu/_preprocessing/_normalisation.py
+++ b/msmu/_preprocessing/_normalisation.py
@@ -5,7 +5,7 @@ from scipy.interpolate import interp1d
 from scipy.stats import rankdata
 from sklearn.linear_model import Ridge
 
-from typing import Callable
+from typing import Callable, Literal, get_args
 
 from .._utils._mudata import get_anndata_mod, get_mudata_mod_as_mutable
 from .._core._blockdiag import to_dense_df
@@ -13,9 +13,15 @@ from ..logging_utils import get_logger
 
 logger = get_logger(__name__)
 
+NormalisationMethod = Literal["median", "median_center", "quantile", "total_sum"]
+# Runtime tuple derived from the Literal so the accepted methods have a single source of truth.
+_NORMALISATION_METHODS: tuple[str, ...] = get_args(NormalisationMethod)
+
 
 class Normalisation:
-    def __init__(self, method: str, axis: str) -> None:
+    def __init__(self, method: NormalisationMethod, axis: str) -> None:
+        if method not in _NORMALISATION_METHODS:
+            raise ValueError(f"Unknown normalisation method '{method}'. Choose from {_NORMALISATION_METHODS}.")
         self._method_call: Callable = getattr(self, f"_{method}")
         self._axis = axis
 
@@ -33,7 +39,7 @@ class Normalisation:
         return normalise_median_center(arr=arr)
 
     def _total_sum(self, arr) -> np.ndarray:
-        return normalise_total_sum()
+        return normalise_total_sum(arr)
 
     def normalise(self, arr) -> np.ndarray:
         na_idx = np.isnan(arr)
@@ -127,9 +133,27 @@ def normalise_median_center(arr: np.ndarray) -> np.ndarray:
     return median_centered_data
 
 
-def normalise_total_sum():
-    """Total sum normalisation of data"""
-    raise NotImplementedError("Total sum normalisation is not implemented yet.")
+def normalise_total_sum(arr: np.ndarray) -> np.ndarray:
+    """Total-intensity (constant-sum) normalisation.
+
+    Rescales every sample so its summed intensity equals ``T`` -- the median of the per-sample totals
+    -- correcting sample-to-sample loading / injection differences while leaving within-sample feature
+    ratios unchanged. ``arr`` is oriented (features x samples) here (``Normalisation`` transposes the
+    obs axis before calling), so the totals are taken per column.
+
+    The input is assumed log2-transformed, matching the msmu convention that ``normalise`` runs after
+    ``log2_transform``. Summing log values is meaningless (it yields the log of the product, not the
+    total), so each sample total is computed on the linear scale (``2 ** arr``) and the rescale is
+    returned to log2. On the log2 scale this reduces to a per-sample additive shift
+    ``log2(T) - log2(S_i)``. Structurally-absent cells (NaN) contribute nothing to the total and stay
+    NaN in the result.
+    """
+    linear_values: np.ndarray = np.exp2(arr.astype(np.float64))
+    sample_totals: np.ndarray = np.nansum(linear_values, axis=0)
+    target_total: float = np.median(sample_totals)
+    per_sample_shift: np.ndarray = np.log2(target_total) - np.log2(sample_totals)
+
+    return arr + per_sample_shift
 
 
 class PTMProteinAdjuster:

--- a/msmu/_preprocessing/_normalise.py
+++ b/msmu/_preprocessing/_normalise.py
@@ -9,7 +9,7 @@ from .._utils._mudata import get_anndata_mod
 from .._core._provenance import uns_logger
 from .._core._blockdiag import dense_block, is_sparse, sparse_apply_elementwise
 from ..logging_utils import get_logger
-from ._normalisation import Normalisation, PTMProteinAdjuster
+from ._normalisation import Normalisation, NormalisationMethod, PTMProteinAdjuster
 
 logger = get_logger(__name__)
 
@@ -95,7 +95,7 @@ def scale_data(
 @uns_logger
 def normalise(
     mdata: md.MuData,
-    method: str,
+    method: NormalisationMethod,
     modality: str,
     layer: str | None = None,
     batch_key: str | None = None,
@@ -107,7 +107,7 @@ def normalise(
 
     Parameters:
         mdata: MuData object to normalise.
-        method: Normalisation method to use. Options are 'quantile', 'median', 'total_sum (not implemented)'.
+        method: Normalisation method to use. Options are 'quantile', 'median', 'total_sum'.
         modality: Modality to normalise.
         layer: Layer to normalise. If None, the default layer (.X) will be used.
         batch_key: Column name in ``adata.obs`` defining batches. If provided, normalisation
@@ -154,15 +154,19 @@ def normalise(
     obs_groups = adata.obs[batch_key].to_numpy() if batch_key is not None else None
     var_groups = adata.var[fraction_key].to_numpy() if fraction_key is not None else None
 
-    # Per-sample median centering (axis="obs", no batch/fraction grouping) is computable directly
-    # on the sparse block-diagonal -- each obs row's stored values are centered independently -- so
-    # it keeps the ``.X`` sparse instead of materialising the (samples x features) dense matrix. This
-    # is the common PSM-level TMT/DIA normalisation. Other methods (quantile) or grouped
-    # normalisation still densify (NaN for absent, dtype matching the dense path).
-    if is_sparse(raw_arr) and method in ("median", "median_center") and obs_groups is None and var_groups is None:
+    # Per-sample normalisation (axis="obs", no batch/fraction grouping) is computable directly on the
+    # sparse block-diagonal -- each obs row's stored values are rescaled independently -- so it keeps
+    # the ``.X`` sparse instead of materialising the (samples x features) dense matrix. This covers the
+    # common PSM-level TMT/DIA normalisations: median / median_center centre each row, and total_sum
+    # rescales each row to a common total intensity. Other methods (quantile) or grouped normalisation
+    # still densify (NaN for absent, dtype matching the dense path).
+    is_ungrouped_sparse = is_sparse(raw_arr) and obs_groups is None and var_groups is None
+    if is_ungrouped_sparse and method in ("median", "median_center"):
         normalised_arr = _median_normalise_per_sample_sparse(
             raw_arr, add_global_median=(method == "median")
         )
+    elif is_ungrouped_sparse and method == "total_sum":
+        normalised_arr = _total_sum_normalise_per_sample_sparse(raw_arr)
     else:
         if is_sparse(raw_arr):
             raw_arr = dense_block(raw_arr).astype(raw_arr.dtype)
@@ -184,7 +188,7 @@ def normalise(
 
 def normalize(
     mdata: md.MuData,
-    method: str,
+    method: NormalisationMethod,
     modality: str,
     layer: str | None = None,
     batch_key: str | None = None,
@@ -233,6 +237,33 @@ def _median_normalise_per_sample_sparse(matrix, add_global_median: bool):
         if end > start:
             values = csr.data[start:end]
             csr.data[start:end] = values - np.median(values) + global_median
+    return csr
+
+
+def _total_sum_normalise_per_sample_sparse(matrix):
+    """Per-sample total-intensity normalisation of a sparse block-diagonal, without densifying.
+
+    Mirrors the dense ``total_sum`` path: each obs row is rescaled so its summed intensity equals the
+    median of the per-sample totals. The input is assumed log2-transformed, so each row's total is
+    taken on the linear scale (``2 ** data``) and the rescale is applied as an additive shift on the
+    stored log2 values -- only ``.data`` is rewritten, so structurally-absent cells stay absent and the
+    result stays sparse. The stored dtype is preserved (the shift is cast to it) so values round
+    identically to the dense path. All-absent rows (no stored data) are left untouched and excluded
+    from the median, matching the dense path's all-NaN-row filter.
+    """
+    csr = matrix.tocsr(copy=True)
+    sample_totals = np.full(csr.shape[0], np.nan, dtype=np.float64)
+    for row in range(csr.shape[0]):
+        start, end = csr.indptr[row], csr.indptr[row + 1]
+        if end > start:
+            sample_totals[row] = np.exp2(csr.data[start:end].astype(np.float64)).sum()
+
+    log2_target_total = np.log2(np.nanmedian(sample_totals))
+    for row in range(csr.shape[0]):
+        start, end = csr.indptr[row], csr.indptr[row + 1]
+        if end > start:
+            per_sample_shift = log2_target_total - np.log2(sample_totals[row])
+            csr.data[start:end] = csr.data[start:end] + csr.dtype.type(per_sample_shift)
     return csr
 
 

--- a/tests/test_preprocessing_normalisation.py
+++ b/tests/test_preprocessing_normalisation.py
@@ -30,9 +30,36 @@ def test_normalise_quantile_shape_and_nans():
     assert np.isnan(norm[0, 1])
 
 
-def test_normalise_total_sum_raises():
-    with pytest.raises(NotImplementedError):
-        normalise_total_sum()
+def test_normalise_total_sum_scales_columns_to_median_total():
+    """total_sum rescales each sample (a column, in the features x samples orientation it receives) so
+    its linear total equals T = the median of the per-sample totals."""
+    arr = np.log2(np.array([[100.0, 50.0, 25.0], [100.0, 50.0, 25.0]]))  # 2 features x 3 samples; totals 200/100/50
+    out = normalise_total_sum(arr)
+    assert np.allclose(np.nansum(2.0**out, axis=0), 100.0)  # T = median(200, 100, 50) = 100
+
+
+def test_normalise_total_sum_removes_pure_loading_and_keeps_within_sample_structure():
+    """A per-sample scalar shift: a sample loaded 2x (a +1 log2 shift) collapses onto the other, and the
+    differences between features within a sample are unchanged."""
+    base = np.array([[1.0], [3.0], [2.0], [4.0]])  # 4 features x 1 sample
+    arr = np.hstack([base, base + 1.0])  # sample 1 = sample 0 at 2x linear loading (features x samples)
+    out = normalise_total_sum(arr)
+    assert np.allclose(out[:, 0], out[:, 1])  # pure loading difference removed
+    assert np.allclose(np.diff(out[:, 0]), np.diff(base[:, 0]))  # within-sample structure preserved
+
+
+def test_total_sum_via_normalisation_preserves_nan():
+    """The Normalisation wrapper (axis="obs") restores structurally-absent cells to NaN."""
+    arr = np.array([[1.0, np.nan, 3.0], [2.0, 4.0, 5.0]])  # samples x features
+    out = Normalisation(method="total_sum", axis="obs").normalise(arr=arr)
+    assert np.isnan(out[0, 1])
+    assert not np.isnan(out[0, 0])
+
+
+def test_normalisation_rejects_unknown_method():
+    """An unrecognised method fails fast with a clear ValueError rather than a cryptic AttributeError."""
+    with pytest.raises(ValueError, match="Unknown normalisation method"):
+        Normalisation(method="not_a_method", axis="obs")
 
 
 def test_ptm_protein_adjuster_ratio(ptm_mdata, global_mdata):

--- a/tests/test_preprocessing_normalise_sparse.py
+++ b/tests/test_preprocessing_normalise_sparse.py
@@ -102,6 +102,7 @@ def test_log2_is_nan_aware_never_zero_fills():
         (normalise, {"method": "median"}),
         (normalise, {"method": "median_center"}),
         (normalise, {"method": "quantile"}),
+        (normalise, {"method": "total_sum"}),
     ],
 )
 def test_sparse_layer_matches_dense(func, kwargs):
@@ -144,3 +145,11 @@ def test_normalise_quantile_still_densifies():
     back to the NaN-aware densify path. Pins the intended boundary of the sparse fast-path."""
     out = normalise(_make_sparse(), method="quantile", modality="psm", layer="raw")
     assert not sp.issparse(out["psm"].layers["raw"])
+
+
+def test_normalise_total_sum_keeps_layer_sparse():
+    """Per-sample total-intensity normalisation rescales each obs row's stored values in place, so it
+    must stay sparse rather than materialise the dense matrix."""
+    out = normalise(_make_sparse(), method="total_sum", modality="psm", layer="raw")
+    assert sp.issparse(out["psm"].layers["raw"]), "normalise(total_sum) densified the sparse block-diagonal"
+    assert np.isnan(to_dense_df(out["psm"], layer="raw").to_numpy()).sum() == _n_absent()


### PR DESCRIPTION
## Summary

Implements `normalise(method="total_sum")`, which previously raised `NotImplementedError`. Total-intensity / constant-sum normalisation rescales each sample so its summed intensity equals the median of the per-sample totals, correcting sample-to-sample loading/injection differences while leaving within-sample feature ratios unchanged.

- **Size factor** — each sample's own observed values: `S_i = Σ_j X_ij` (observed-only).
- **Target** — `T = median(S_i)` over samples with data (a global constant, so it cancels from all ratios; median for robustness).
- **Scale** — input is assumed log2-transformed (the msmu convention that `normalise` runs after `log2_transform`). Summing log values is meaningless, so totals are computed on the linear scale (`2**x → sum → log2`), i.e. a per-sample additive shift `log2(T) − log2(S_i)` on the log scale.
- **Sparse** — a block-diagonal fast-path (`_total_sum_normalise_per_sample_sparse`) mirrors the median path: rewrites only `.data`, stays sparse, dtype preserved. `sparse == dense` parity is verified.

Also hardens the shared dispatch (the `method` argument had no validation):

- `method` is validated with a clear `ValueError` (was a cryptic `AttributeError` from `getattr`), symmetric with the existing axis check.
- `method` is typed as a `Literal`, with the accepted-method tuple derived from it via `get_args` as a single source of truth.

## Scope / decisions

- **observed-only** is the definition of total-sum; the detection-depth bias it carries is inherent and documented (the complete-case / shared-feature variant is intentionally not used).
- **No `log_transformed` flag** — total_sum always assumes log2 input like the other methods, so no per-method scale flag is introduced.
- A **separate follow-up** will add a common "was log2 applied before normalise?" check across all methods (out of scope here — it affects median/quantile too, which fail silently on non-log2 input).

## Tests

- Replaced the `test_normalise_total_sum_raises` stub test with correctness tests: median-total equalisation, pure-loading removal, within-sample structure preservation, NaN preservation, and unknown-method validation.
- Added `total_sum` to the sparse-vs-dense parity parametrisation and a keeps-sparse test.
- Full suite: **454 passed / 0 failed**, ruff clean.
