### PR TITLE
[BID-119] Automatic per-feature scale restore in batch correction

### DIFF
--- a/docs/how-it-works/batch_correction.md
+++ b/docs/how-it-works/batch_correction.md
@@ -2,17 +2,19 @@
 
 ## Overview
 
-Batch effects are unwanted variations in the data that arise from differences in experimental conditions, such as different lots, runs, days, or operators. These variations can obscure true biological signals and lead to misleading conclusions. `msmu` provides functions to correct for discrete batch effects using methods like median centering and GIS/IRS for TMT data. Support for batch effects arising from continuous variables (e.g., run order) will be added in future releases.
+Batch effects are unwanted variations in the data that arise from differences in experimental conditions, such as different lots, runs, days, or operators. These variations can obscure true biological signals and lead to misleading conclusions. `msmu` corrects them with median centering, GIS/IRS (for TMT), ComBat, and a continuous (lowess) correction for ordered covariates such as run order.
 
 ## `correct_batch_effect()`
 
 The `correct_batch_effect()` function either:
 
-- Median centering, which standardizes each features to have zero median (can be re-scaled).
-- GIS/IRS normalization, which rescales and corrects batch effect in TMT data using Global Internal Standard (GIS) channels.
+- Median centering, which removes each batch's per-feature median.
+- GIS/IRS normalization, which corrects batch effect in TMT data using Global Internal Standard (GIS) channels.
 - Combat batch effect correction ([pycombat](https://github.com/epigenelabs/pyComBat)).
 - Continuous batch effect correction using lowess regression (referred from [Diagnostics and correction of batch effects in large‐scale proteomic studies: a tutorial](https://pmc.ncbi.nlm.nih.gov/articles/PMC8447595/)).
-  
+
+For `gis`, `median_center`, and `continuous`, the per-feature abundance scale is restored automatically after correction (geometric mean of the per-batch GIS levels for `gis` — classic IRS; per-feature overall median otherwise). The decision is made for the whole modality: if the matrix has cross-batch structure (at least one feature observed in ≥2 batches, as at the peptide/protein level) every feature is restored, so a lone single-batch feature stays on the same abundance scale as the rest; if the matrix is fully block-diagonal (no feature spans ≥2 batches, e.g. a per-plex-split PSM matrix) nothing is restored and the output stays reference-relative, ready to roll up.
+
 
 ```python
 mdata = mm.pp.correct_batch_effect(
@@ -21,8 +23,7 @@ mdata = mm.pp.correct_batch_effect(
     layer=None,                              # layer to correct, default is .X
     category="batch",                        # batch information column in .obs
     method="gis",                            # options: "median_center", "gis", "combat", "continuous"
-    rescale=True,                            # whether to rescale data with median value of original data. Default is True (for GIS, median_center, continuous)
-    gis_sample=["POOLED_1", "POOLED_2"],     # GIS channel names (for TMT data only)
+    gis_samples=["POOLED_1", "POOLED_2"],    # GIS channel names (for TMT data only)
     drop_gis=True,                           # whether to drop GIS channels after correction. Default is True
     log_transformed=True                     # whether data is log-transformed. Default is True
 )
@@ -43,3 +44,12 @@ mdata = mm.pp.correct_batch_effect(
     method="continuous",
 )
 ```
+
+## Usage notes
+
+- **Level.** Correct **after** summarising to peptide/protein, not on the raw PSM matrix. At peptide/protein a feature is shared across batches, so the scale restores to abundance and the matrices are dense and small. A per-plex-split PSM matrix is block-diagonal (each feature lives in one plex): the correction still runs, but the output stays reference-relative — roll up first, then correct.
+- **`gis`** — TMT/IRS. Needs the pooled reference (GIS) channels named in `gis_samples`, present in every plex. Assumes log-transformed input; normalizes each feature to its plex reference and restores the IRS geometric-mean scale.
+- **`median_center`** — removes each batch's per-feature median; assumes a balanced design (batch medians comparable). Works at any level.
+- **`combat`** — pycombat; models batch location/scale and handles its own scaling (no separate restore).
+- **`continuous`** — lowess against an **ordered** covariate (e.g. run / acquisition order in `category`), not a nominal batch label.
+- **Output scale.** Abundance on a shared (peptide/protein) matrix; reference-relative (ratio / centred) on a block-diagonal (raw split-PSM) matrix. The restore is a per-feature constant, so it does not change differential-expression contrasts — it only sets the abundance scale.

--- a/msmu/_preprocessing/_batch_correction.py
+++ b/msmu/_preprocessing/_batch_correction.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Literal
 import mudata as md
 import numpy as np
@@ -12,6 +13,13 @@ from ..logging_utils import get_logger
 
 logger = get_logger(__name__)
 
+# A matrix has cross-batch structure once at least one feature is observed in this many batches (a
+# cross-batch reference then exists). If NO feature reaches it the matrix is fully block-diagonal
+# (e.g. a per-plex-split PSM matrix) and the scale is not restored -- restoring a single-batch
+# feature against its own level would merely reconstruct the original and undo the correction (see
+# ``BatchCorrector._restore_mask``).
+MIN_BATCHES_FOR_SCALE_RESTORE: int = 2
+
 
 @uns_logger
 def correct_batch_effect(
@@ -22,12 +30,21 @@ def correct_batch_effect(
     layer: str | None = None,
     gis_samples: list[str] | None = None,
     drop_gis: bool = True,
-    rescale: bool = True,
     log_transformed: bool = True,
 ) -> md.MuData:
     """
     Batch correction methods for MuData object.
     GIS-based normalization, median centering, ComBat, and continuous batch correction (with lowess) are supported.
+
+    For 'gis', 'median_center', and 'continuous' the per-feature abundance scale is restored after
+    correction (gis: the geometric mean of the per-batch GIS levels, i.e. classic IRS [Plubell et
+    al. 2017]; median_center/continuous: the per-feature overall median). Restoration is decided for
+    the modality as a whole: when the matrix has cross-batch structure (at least one feature observed
+    in >=2 batches, as at the peptide/protein level) every observed feature is restored -- a
+    single-batch feature to its own level, so it stays on the same abundance scale as the rest. When
+    the matrix is fully block-diagonal (no feature spans >=2 batches, e.g. a per-plex-split PSM
+    matrix) nothing is restored and the output stays reference-relative, ready to roll up. ComBat
+    scales itself.
 
     Parameters:
         mdata: MuData object to batch correct.
@@ -37,7 +54,6 @@ def correct_batch_effect(
         layer: Layer to batch correct. If None, the default layer (.X) will be used.
         gis_samples: List of GIS samples.
         drop_gis: If True, GIS samples will be dropped after correction. Default is True.
-        rescale: If True, rescale the data after batch correction with median value across dataset (except combat).
         log_transformed: If True, data is assumed to be log-transformed. Default is True.
 
     Returns:
@@ -61,9 +77,6 @@ def correct_batch_effect(
         corrected_arr: np.ndarray = batch_corrector.median_center()
     elif method == "combat":
         corrected_arr: np.ndarray = batch_corrector.combat()
-        if rescale:
-            logger.warning("Rescaling is not supported after ComBat correction; continuing without rescaling.")
-            rescale = False
     elif method == "continuous":
         corrected_arr: np.ndarray = batch_corrector.continuous()
     else:
@@ -74,9 +87,6 @@ def correct_batch_effect(
             f"Method {method}. not recognised. Please choose from 'gis', 'median_center', 'combat', 'continuous'"
         )
 
-    if rescale:
-        logger.info("Rescaling data after batch correction.")
-        corrected_arr: np.ndarray = batch_corrector.rescale()
     logger.debug(
         "Batch correction '%s' produced array with shape %s.",
         method,
@@ -120,18 +130,38 @@ class BatchCorrector:
 
     def gis(self, gis_samples: list[str]):
         self.corrected_arr = self.original_arr.copy()
-        batches, batch_idx, _ = self._make_batch_matrix()
+        batches, batch_idx = self._make_batch_matrix()
         logger.debug("Applying GIS batch correction across %d batches.", len(batches))
 
         n_batches = len(batches)
 
         gis_idx = self._make_gis_index(gis_samples=gis_samples)
 
-        gis_avg_arr = np.ndarray((n_batches, self.corrected_arr.shape[1]), dtype=float)
-        for i in range(n_batches):
-            gis_avg_arr[i, :] = np.nanmean(self.corrected_arr[gis_idx & (batch_idx == i), :], axis=0)
+        # Per-batch reference level, per feature (GIS channels within a batch are averaged). NaN for
+        # a (batch, feature) with no observed GIS channel, so a batch missing the reference drops out.
+        # The IRS reference target (Plubell et al. 2017) is the geometric mean of these per-batch
+        # levels across batches (the arithmetic mean in log space); both come straight from the GIS
+        # levels, so they are computed here before the correction mutates ``corrected_arr``.
+        gis_avg_arr = np.full((n_batches, self.corrected_arr.shape[1]), np.nan, dtype=float)
+        with warnings.catch_warnings():
+            # An all-NaN slice (a batch with no observed GIS channel for a feature) is the expected
+            # "no reference here" sentinel -> NaN; silence the empty-slice warning (common on a
+            # block-diagonal matrix where a feature exists in only one batch).
+            warnings.filterwarnings("ignore", message="Mean of empty slice")
+            for i in range(n_batches):
+                gis_avg_arr[i, :] = np.nanmean(self.corrected_arr[gis_idx & (batch_idx == i), :], axis=0)
+            if self.log_transformed:
+                reference_target = np.nanmean(gis_avg_arr, axis=0)
+            else:
+                reference_target = np.exp(np.nanmean(np.log(gis_avg_arr), axis=0))
+        restore_mask = self._restore_mask(np.sum(~np.isnan(gis_avg_arr), axis=0))
+
         correction_factor = gis_avg_arr[batch_idx, :]
         self.corrected_arr = self._correct(correction_factor=correction_factor)
+
+        # Restore the per-feature reference scale so the abundance axis is preserved instead of
+        # collapsed to a reference ratio.
+        self._restore_scale(reference_target=reference_target, restore_mask=restore_mask)
 
         return self.corrected_arr
 
@@ -150,7 +180,7 @@ class BatchCorrector:
 
     def median_center(self):
         self.corrected_arr = self.original_arr.copy()
-        _, batch_idx, _ = self._make_batch_matrix()
+        _, batch_idx = self._make_batch_matrix()
         logger.debug(
             "Applying median-centering batch correction across %d batches.",
             len(np.unique(batch_idx)),
@@ -161,6 +191,12 @@ class BatchCorrector:
         correction_factor = median_arr[batch_idx, :]
         self.corrected_arr = self._correct(correction_factor=correction_factor)
 
+        # Restore the per-feature overall median so the abundance axis is preserved instead of every
+        # batch collapsing to a common centre (analogous to the gis IRS restore).
+        reference_target = np.nanmedian(self.original_arr, axis=0)
+        restore_mask = self._restore_mask(np.sum(~np.isnan(median_arr), axis=0))
+        self._restore_scale(reference_target=reference_target, restore_mask=restore_mask)
+
         return self.corrected_arr
 
     def combat(self):
@@ -168,7 +204,7 @@ class BatchCorrector:
         ComBat batch correction using pycombat.
         https://epigenelabs.github.io/pyComBat/
         """
-        _, batch_idx, _ = self._make_batch_matrix()
+        _, batch_idx = self._make_batch_matrix()
         logger.debug(
             "Applying ComBat batch correction across %d batches.",
             len(np.unique(batch_idx)),
@@ -196,15 +232,19 @@ class BatchCorrector:
     def continuous(self):
         """
         Continuous batch correction using lowess.
-        reference: Diagnostics and correction of batch effects in large‐scale proteomic studies: a tutorial
+
+        Treats ``category`` as an ORDERED continuous covariate (e.g. acquisition / run order): the
+        per-feature trend against the batch index is fitted with lowess and removed. It is not meant
+        for an unordered/nominal batch label. Note the batch index orders ``category`` by its
+        sorted-unique values, so a numeric run order stored as strings sorts lexicographically.
+
+        reference: Diagnostics and correction of batch effects in large-scale proteomic studies: a tutorial
         https://pmc.ncbi.nlm.nih.gov/articles/PMC8447595/
         """
         self.corrected_arr = self.original_arr.copy()
-        _, batch_idx, _ = self._make_batch_matrix()
-        logger.debug(
-            "Applying continuous batch correction across %d batches.",
-            len(np.unique(batch_idx)),
-        )
+        batches, batch_idx = self._make_batch_matrix()
+        n_batches = len(batches)
+        logger.debug("Applying continuous batch correction across %d batches.", n_batches)
 
         res_lowess = np.full_like(self.corrected_arr, np.nan)
         for i in range(self.corrected_arr.shape[1]):
@@ -220,25 +260,61 @@ class BatchCorrector:
             )
             res_lowess[:, i] = res
 
-        # res_lowess = res_lowess.replace(np.nan, 0)
         self.corrected_arr = self._correct(correction_factor=res_lowess)
 
+        # lowess removes each feature's level along with its batch-order trend; restore the
+        # per-feature overall median (like median_center).
+        reference_target = np.nanmedian(self.original_arr, axis=0)
+        restore_mask = self._restore_mask(self._feature_batch_count(batch_idx, n_batches))
+        self._restore_scale(reference_target=reference_target, restore_mask=restore_mask)
+
         return self.corrected_arr
 
-    def rescale(self):
-        total_median = np.nanmedian(self.original_arr.flatten())
-        self.corrected_arr += total_median
-
-        return self.corrected_arr
-
-    def _make_batch_matrix(self) -> np.ndarray:
+    def _make_batch_matrix(self) -> tuple[np.ndarray, np.ndarray]:
         obs_category = self.mdata.obs[self.category]
         batches, batch_idx = np.unique(obs_category, return_inverse=True)
-        n_batches = len(batches)
+        return batches, batch_idx
 
-        batch_idx_arr = np.eye(n_batches)[batch_idx]
+    def _feature_batch_count(self, batch_idx: np.ndarray, n_batches: int) -> np.ndarray:
+        """Per feature, the number of batches with at least one observed (non-NaN) value."""
+        batch_count = np.zeros(self.original_arr.shape[1], dtype=int)
+        for batch in range(n_batches):
+            batch_count += np.any(~np.isnan(self.original_arr[batch_idx == batch]), axis=0)
+        return batch_count
 
-        return batches, batch_idx, batch_idx_arr
+    def _restore_mask(self, feature_batch_count: np.ndarray) -> np.ndarray:
+        """Which features to restore, decided for the matrix as a whole (not per feature).
+
+        When any feature is observed in >=``MIN_BATCHES_FOR_SCALE_RESTORE`` batches the matrix has
+        cross-batch structure (e.g. peptide/protein level), so every observed feature is restored --
+        a lone single-batch feature to its own level, keeping it on the same abundance scale as the
+        rest rather than stranded at the reference-relative origin. When no feature spans that many
+        batches the matrix is fully block-diagonal (e.g. a per-plex-split PSM matrix): restoring a
+        single-batch feature against its own level would just reconstruct the original and undo the
+        correction, so nothing is restored and the output stays reference-relative (ready to roll up).
+        """
+        if np.any(feature_batch_count >= MIN_BATCHES_FOR_SCALE_RESTORE):
+            return feature_batch_count >= 1
+        return np.zeros_like(feature_batch_count, dtype=bool)
+
+    def _restore_scale(self, reference_target: np.ndarray, restore_mask: np.ndarray) -> None:
+        """Add the per-feature reference target back (for the features in ``restore_mask``) so the
+        abundance scale is preserved. Additive in log space, multiplicative otherwise. Which features
+        are restored is decided by :meth:`_restore_mask`.
+        """
+        n_restored = int(restore_mask.sum())
+        logger.info(
+            "Restoring per-feature scale for %d/%d features (%d left reference-relative).",
+            n_restored,
+            restore_mask.size,
+            restore_mask.size - n_restored,
+        )
+        if n_restored == 0:
+            return
+        if self.log_transformed:
+            self.corrected_arr[:, restore_mask] += reference_target[restore_mask]
+        else:
+            self.corrected_arr[:, restore_mask] *= reference_target[restore_mask]
 
     def _correct(self, correction_factor: np.ndarray) -> np.ndarray:
         if self.log_transformed:

--- a/tests/test_preprocessing_correct_batch.py
+++ b/tests/test_preprocessing_correct_batch.py
@@ -1,7 +1,17 @@
 import pytest
 import numpy as np
+import pandas as pd
+from anndata import AnnData
+from mudata import MuData
 
 from msmu._preprocessing._batch_correction import correct_batch_effect
+
+
+def _mdata_with_batch(x, obs_names, var_names, batch) -> MuData:
+    # correct_batch_effect reads the batch label from the MuData-level ``mdata.obs``.
+    mdata = MuData({"psm": AnnData(X=x, obs=pd.DataFrame(index=obs_names), var=pd.DataFrame(index=var_names))})
+    mdata.obs["batch"] = np.asarray(batch)
+    return mdata
 
 
 def test_correct_batch_effect_gis_drops_samples(simple_mdata):
@@ -9,7 +19,6 @@ def test_correct_batch_effect_gis_drops_samples(simple_mdata):
         simple_mdata,
         modality="psm",
         method="gis",
-        rescale=False,
         category="batch",
         gis_samples=["gis1", "gis2"],
         drop_gis=True,
@@ -22,7 +31,6 @@ def test_correct_batch_effect_gis_keep_samples(simple_mdata):
         simple_mdata,
         modality="psm",
         method="gis",
-        rescale=False,
         category="batch",
         gis_samples=["gis1", "gis2"],
         drop_gis=False,
@@ -31,11 +39,12 @@ def test_correct_batch_effect_gis_keep_samples(simple_mdata):
 
 
 def test_correct_batch_effect_gis(simple_mdata):
+    # Both features appear in both batches, so the IRS scale is restored: the reference-relative
+    # correction ([[-5, -4], ...]) plus the per-feature geomean reference target [8.5, 9.0].
     out = correct_batch_effect(
         simple_mdata,
         modality="psm",
         method="gis",
-        rescale=False,
         category="batch",
         gis_samples=["gis1", "gis2"],
         log_transformed=True,
@@ -45,12 +54,12 @@ def test_correct_batch_effect_gis(simple_mdata):
         out["psm"].X,
         np.array(
             [
-                [-5.0, -4.0],
-                [-3.0, -2.0],
-                [0.0, 0.0],
-                [-4.0, -4.0],
-                [-2.0, -2.0],
-                [0.0, 0.0],
+                [3.5, 5.0],
+                [5.5, 7.0],
+                [8.5, 9.0],
+                [4.5, 5.0],
+                [6.5, 7.0],
+                [8.5, 9.0],
             ]
         ),
     )
@@ -61,25 +70,26 @@ def test_correct_batch_effect_gis_protein(simple_mdata_protein):
         simple_mdata_protein,
         modality="protein",
         method="gis",
-        rescale=False,
         category="batch",
         gis_samples=["gis1", "gis2"],
         log_transformed=True,
         drop_gis=False,
     )
+    # protein reference target (geomean of per-batch GIS levels) = [(5 + 11) / 2, (6 + 12) / 2] = [8, 9]
     assert np.allclose(
         out["protein"].X,
         np.array(
             [
-                [-4.0, -4.0],
-                [-2.0, -2.0],
-                [0.0, 0.0],
-                [-4.0, -4.0],
-                [-2.0, -2.0],
-                [0.0, 0.0],
+                [4.0, 5.0],
+                [6.0, 7.0],
+                [8.0, 9.0],
+                [4.0, 5.0],
+                [6.0, 7.0],
+                [8.0, 9.0],
             ]
         ),
     )
+    # correcting the protein modality leaves psm untouched
     assert np.allclose(
         out["psm"].X,
         np.array(
@@ -95,38 +105,47 @@ def test_correct_batch_effect_gis_protein(simple_mdata_protein):
     )
 
 
-def test_correct_batch_effect_gis_rescale(simple_mdata):
-    total_median = np.median(simple_mdata.mod["psm"].X.flatten())
-    answer = np.array(
+def test_correct_batch_effect_gis_shared_restores_orphan():
+    # The matrix has cross-batch structure (v1 has a GIS reference in both batches), so every feature
+    # is restored -- including v2, whose reference exists only in b1. v2 is restored against its own
+    # b1 level (back to its abundance) instead of being stranded at the reference-relative origin, so
+    # it stays on the same scale as v1. Pins the global (any-vs-none) restore decision.
+    x = np.array(
         [
-            [-5.0, -4.0],
-            [-3.0, -2.0],
-            [0.0, 0.0],
-            [-4.0, -4.0],
-            [-2.0, -2.0],
-            [0.0, 0.0],
+            [1.0, 10.0],  # s1   (b1)
+            [4.0, 8.0],  # gis1 (b1 reference)
+            [5.0, 20.0],  # s2   (b2)
+            [12.0, np.nan],  # gis2 (b2 reference; v2 unobserved)
         ]
     )
-
+    mdata = _mdata_with_batch(x, ["s1", "gis1", "s2", "gis2"], ["v1", "v2"], ["b1", "b1", "b2", "b2"])
     out = correct_batch_effect(
-        simple_mdata,
+        mdata,
         modality="psm",
         method="gis",
-        rescale=True,
         category="batch",
         gis_samples=["gis1", "gis2"],
-        log_transformed=True,
         drop_gis=False,
     )
-    assert np.allclose(out["psm"].X, (answer + total_median))
+    # v1 target 8 (mean of 4, 12); v2 target 8 (its only b1 level) -> both on the abundance scale.
+    expected = np.array(
+        [
+            [5.0, 10.0],
+            [8.0, 8.0],
+            [1.0, np.nan],
+            [8.0, np.nan],
+        ]
+    )
+    np.testing.assert_allclose(out["psm"].X, expected, equal_nan=True)
 
 
 def test_correct_batch_effect_median_center(simple_mdata):
+    # Both features in both batches -> restored: per-batch-median correction plus the per-feature
+    # overall median [6.5, 7.0].
     out = correct_batch_effect(
         simple_mdata,
         modality="psm",
         method="median_center",
-        rescale=False,
         category="batch",
         log_transformed=True,
     )
@@ -134,15 +153,65 @@ def test_correct_batch_effect_median_center(simple_mdata):
         out["psm"].X,
         np.array(
             [
-                [-2.0, -2.0],
-                [0.0, 0.0],
-                [3.0, 2.0],
-                [-2.0, -2.0],
-                [0.0, 0.0],
-                [2.0, 2.0],
+                [4.5, 5.0],
+                [6.5, 7.0],
+                [9.5, 9.0],
+                [4.5, 5.0],
+                [6.5, 7.0],
+                [8.5, 9.0],
             ]
         ),
     )
+
+
+def test_correct_batch_effect_median_center_blockdiag_skips_restore():
+    # Fully block-diagonal: every feature lives in one batch only, so no cross-batch centre exists.
+    # Restore must be skipped -- the output stays centred (reference-relative), NaN never filled.
+    x = np.array(
+        [
+            [1.0, 2.0, np.nan, np.nan],  # s1 (b1)
+            [3.0, 4.0, np.nan, np.nan],  # s2 (b1)
+            [np.nan, np.nan, 5.0, 6.0],  # s3 (b2)
+            [np.nan, np.nan, 7.0, 8.0],  # s4 (b2)
+        ]
+    )
+    mdata = _mdata_with_batch(x, ["s1", "s2", "s3", "s4"], ["v1", "v2", "v3", "v4"], ["b1", "b1", "b2", "b2"])
+    out = correct_batch_effect(mdata, modality="psm", method="median_center", category="batch")
+    expected = np.array(
+        [
+            [-1.0, -1.0, np.nan, np.nan],
+            [1.0, 1.0, np.nan, np.nan],
+            [np.nan, np.nan, -1.0, -1.0],
+            [np.nan, np.nan, 1.0, 1.0],
+        ]
+    )
+    np.testing.assert_allclose(out["psm"].X, expected, equal_nan=True)
+
+
+def test_correct_batch_effect_median_center_shared_restores_orphan():
+    # v1 spans both batches; v2 is only in b1. Because the matrix has cross-batch structure (v1),
+    # every feature is restored -- v2 too, against its own overall median (back to its abundance)
+    # rather than left at the centred origin, so it stays on v1's scale. Global restore decision.
+    x = np.array(
+        [
+            [1.0, 10.0],  # s1 (b1)
+            [3.0, 12.0],  # s2 (b1)
+            [5.0, np.nan],  # s3 (b2)
+            [7.0, np.nan],  # s4 (b2)
+        ]
+    )
+    mdata = _mdata_with_batch(x, ["s1", "s2", "s3", "s4"], ["v1", "v2"], ["b1", "b1", "b2", "b2"])
+    out = correct_batch_effect(mdata, modality="psm", method="median_center", category="batch")
+    # v1 target 4, v2 target 11 (its overall median) -> v2 back to ~its abundance, not the origin.
+    expected = np.array(
+        [
+            [3.0, 10.0],
+            [5.0, 12.0],
+            [3.0, np.nan],
+            [5.0, np.nan],
+        ]
+    )
+    np.testing.assert_allclose(out["psm"].X, expected, equal_nan=True)
 
 
 def test_correct_batch_effect_gis_missing_raises(simple_mdata):
@@ -151,7 +220,6 @@ def test_correct_batch_effect_gis_missing_raises(simple_mdata):
             simple_mdata,
             modality="psm",
             method="gis",
-            rescale=False,
             category="batch",
             gis_samples=["gis4", "gis5"],
         )
@@ -172,7 +240,6 @@ def test_correct_batch_effect_combat(simple_mdata):
         simple_mdata,
         modality="psm",
         method="combat",
-        rescale=False,
         category="batch",
         log_transformed=True,
     )
@@ -184,7 +251,6 @@ def test_correct_batch_effect_continuous(simple_mdata):
         simple_mdata,
         modality="psm",
         method="continuous",
-        rescale=False,
         category="batch",
         log_transformed=True,
     )


### PR DESCRIPTION
## Summary

Replaces the `rescale` parameter of `correct_batch_effect` — a single global-median add-back that flattened every feature to one level — with automatic **per-feature abundance-scale restoration** after `gis` / `median_center` / `continuous` correction.

- **gis**: restores the geometric mean of the per-batch GIS reference levels (classic IRS, Plubell et al. 2017).
- **median_center / continuous**: restores the per-feature overall median.
- **combat**: scales itself; unaffected.

## Restore decision (no knob)

Decided per **modality**, not per feature:

- **Shared matrix** (any feature observed in ≥2 batches, e.g. peptide/protein): every observed feature is restored — a lone single-batch feature to its own level, so it stays on the same abundance scale as the rest instead of being stranded at the reference-relative origin.
- **Fully block-diagonal** (no feature spans ≥2 batches, e.g. a per-plex-split PSM matrix): nothing is restored; the output stays reference-relative, ready to roll up.

There is no parameter, by design: restoring a single-batch feature against its own level on a block-diagonal matrix would reconstruct the original and undo the correction.

## Also

- Remove the dead one-hot batch matrix from `_make_batch_matrix`.
- Silence the expected "Mean of empty slice" warning during block-diagonal GIS averaging.
- Update `docs/how-it-works/batch_correction.md` (behaviour + usage notes).

## Testing

- `tests/test_preprocessing_correct_batch.py` reworked: removed the `rescale` test; updated numeric expectations to the restored (IRS / median) outputs; added block-diagonal-skip and shared-restores-orphan cases (all hand-computed).
- Full unit suite: **451 passed**, ruff clean.
