### PR TITLE
feat(preprocessing): normalise/scale sparse-in → sparse-out, incl. grouped (BID-127)

### DIFF
--- a/msmu/_preprocessing/_normalise.py
+++ b/msmu/_preprocessing/_normalise.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 from .._utils._mudata import get_anndata_mod
 from .._core._provenance import uns_logger
-from .._core._blockdiag import dense_block, is_sparse, sparse_apply_elementwise
+from .._core._blockdiag import dense_block, is_sparse, sparse_apply_elementwise, to_observed_sparse
 from ..logging_utils import get_logger
 from ._normalisation import Normalisation, NormalisationMethod, PTMProteinAdjuster
 
@@ -77,12 +77,19 @@ def scale_data(
         raw_arr: np.ndarray = adata.layers[layer]
 
     # Scaling needs per-feature mean/std across all samples, so it densifies (NaN for absent).
-    if is_sparse(raw_arr):
-        raw_arr = dense_block(raw_arr).astype(raw_arr.dtype)
+    input_was_sparse = is_sparse(raw_arr)
+    if input_was_sparse:
+        input_dtype = raw_arr.dtype
+        raw_arr = dense_block(raw_arr).astype(input_dtype)
 
     mean_arr: np.ndarray = np.nanmean(raw_arr, axis=0)
     std_arr: np.ndarray = np.nanstd(raw_arr, axis=0)
-    scaled_arr: np.ndarray = (raw_arr - mean_arr) / std_arr
+    scaled_arr = (raw_arr - mean_arr) / std_arr
+
+    # Standardising leaves the observed pattern unchanged, so re-sparsify a sparse input back to a
+    # sparse output -- recovering the memory the densify spent on the absent cells.
+    if input_was_sparse:
+        scaled_arr = to_observed_sparse(scaled_arr, dtype=input_dtype)
 
     if layer is None:
         adata.X = scaled_arr
@@ -162,8 +169,10 @@ def normalise(
     if is_sparse(raw_arr) and method in ("median", "median_center", "total_sum"):
         normalised_arr = _normalise_per_group_sparse(raw_arr, obs_groups, var_groups, method)
     else:
-        if is_sparse(raw_arr):
-            raw_arr = dense_block(raw_arr).astype(raw_arr.dtype)
+        input_was_sparse = is_sparse(raw_arr)
+        if input_was_sparse:
+            input_dtype = raw_arr.dtype
+            raw_arr = dense_block(raw_arr).astype(input_dtype)
 
         normalised_arr = _normalise_by_groups(
             raw_arr=raw_arr,
@@ -171,6 +180,10 @@ def normalise(
             obs_groups=obs_groups,
             var_groups=var_groups,
         )
+        # quantile densifies to compute (its per-sample rank mapping couples all samples); re-sparsify so
+        # a sparse input yields a sparse output, recovering the memory freed by dropping absent cells.
+        if input_was_sparse:
+            normalised_arr = to_observed_sparse(normalised_arr, dtype=input_dtype)
 
     if layer is None:
         adata.X = normalised_arr

--- a/msmu/_preprocessing/_normalise.py
+++ b/msmu/_preprocessing/_normalise.py
@@ -154,19 +154,13 @@ def normalise(
     obs_groups = adata.obs[batch_key].to_numpy() if batch_key is not None else None
     var_groups = adata.var[fraction_key].to_numpy() if fraction_key is not None else None
 
-    # Per-sample normalisation (axis="obs", no batch/fraction grouping) is computable directly on the
-    # sparse block-diagonal -- each obs row's stored values are rescaled independently -- so it keeps
-    # the ``.X`` sparse instead of materialising the (samples x features) dense matrix. This covers the
-    # common PSM-level TMT/DIA normalisations: median / median_center centre each row, and total_sum
-    # rescales each row to a common total intensity. Other methods (quantile) or grouped normalisation
-    # still densify (NaN for absent, dtype matching the dense path).
-    is_ungrouped_sparse = is_sparse(raw_arr) and obs_groups is None and var_groups is None
-    if is_ungrouped_sparse and method in ("median", "median_center"):
-        normalised_arr = _median_normalise_per_sample_sparse(
-            raw_arr, add_global_median=(method == "median")
-        )
-    elif is_ungrouped_sparse and method == "total_sum":
-        normalised_arr = _total_sum_normalise_per_sample_sparse(raw_arr)
+    # Per-sample normalisation (median / median_center / total_sum) is computable directly on the sparse
+    # block-diagonal -- each obs row is rescaled from its own stored values -- so it stays sparse instead
+    # of materialising the (samples x features) dense matrix, for the common ungrouped case as well as
+    # batch/fraction grouping (each block normalised independently). Quantile is not sparse-native (its
+    # per-sample rank mapping couples all samples), so it falls back to the NaN-aware densify path.
+    if is_sparse(raw_arr) and method in ("median", "median_center", "total_sum"):
+        normalised_arr = _normalise_per_group_sparse(raw_arr, obs_groups, var_groups, method)
     else:
         if is_sparse(raw_arr):
             raw_arr = dense_block(raw_arr).astype(raw_arr.dtype)
@@ -217,54 +211,91 @@ def _partition_indices(groups: np.ndarray | None, length: int) -> list[np.ndarra
     return [np.where(groups == group)[0] for group in unique_groups]
 
 
-def _median_normalise_per_sample_sparse(matrix, add_global_median: bool):
-    """Per-sample (per-obs) median centering of a sparse block-diagonal, without densifying.
+def _normalise_per_group_sparse(matrix, obs_groups, var_groups, method):
+    """Per-sample normalisation of a sparse block-diagonal within each (obs_group x var_group) block,
+    without densifying.
 
-    Matches the dense ``axis="obs"`` median/median_center path: each obs row's stored (observed)
-    values are centered by that row's median, and for ``method="median"`` the dataset-wide median of
-    all stored values is added back. Only ``.data`` is rewritten, so structurally-absent cells stay
-    absent and the result stays sparse. The stored dtype is preserved (not upcast to float64) so the
-    median arithmetic rounds identically to the dense path -- centering subtracts a large median, so
-    even a 1-ULP dtype mismatch would shift a whole row and break value-equality with the dense path.
+    Generalises the ungrouped per-sample path: with ``obs_groups`` and ``var_groups`` both None the
+    whole matrix is a single block (the common PSM-level TMT/DIA case, taken via a whole-row fast
+    path). ``obs_groups`` (batch) partitions rows and ``var_groups`` (fraction) partitions columns;
+    each block is normalised independently, matching the dense ``_normalise_by_groups`` path. Only
+    ``.data`` is rewritten so structurally-absent cells stay absent and the layer stays sparse; the
+    stored dtype is preserved so values round identically to the dense path.
+
+    ``method`` is one of "median" / "median_center" / "total_sum" (quantile is not sparse-native).
     """
     csr = matrix.tocsr(copy=True)
-    if add_global_median and csr.data.size:
-        global_median = np.median(csr.data)
+    row_partitions = _partition_indices(obs_groups, csr.shape[0])
+    # A single ``None`` column-partition keeps the whole-row fast path (no per-row column split) when
+    # no fraction grouping is requested -- covers the hot ungrouped case and batch-only grouping.
+    col_partitions = _partition_indices(var_groups, csr.shape[1]) if var_groups is not None else [None]
+    for row_indices in row_partitions:
+        for col_indices in col_partitions:
+            _normalise_sparse_block(csr, row_indices, col_indices, method)
+    return csr
+
+
+def _normalise_sparse_block(csr, row_indices, col_indices, method):
+    """Collect the stored-cell indices of one (row_indices x col_indices) block, then dispatch to the
+    method's in-place rescaler. ``col_indices=None`` means all columns (whole-row slices -- the hot path,
+    no per-row column split). Rows with no stored cell in the block are skipped and excluded from the
+    block scalar, matching the dense path's all-NaN-row filter. Only stored cells are touched, so absent
+    cells stay absent and the stored dtype is preserved.
+    """
+    indptr, indices = csr.indptr, csr.indices
+    column_mask = None
+    if col_indices is not None:
+        column_mask = np.zeros(csr.shape[1], dtype=bool)
+        column_mask[col_indices] = True
+
+    # Per-row index into ``csr.data`` for this block's cells: a contiguous slice for the whole-row path,
+    # or an explicit position array when a fraction column mask restricts the row.
+    block_cell_indices: list = []
+    for row in row_indices:
+        start, end = indptr[row], indptr[row + 1]
+        if end <= start:
+            continue
+        if column_mask is None:
+            block_cell_indices.append(slice(start, end))
+        else:
+            selected = np.nonzero(column_mask[indices[start:end]])[0]
+            if selected.size:
+                block_cell_indices.append(start + selected)
+    if not block_cell_indices:
+        return
+
+    if method == "total_sum":
+        _rescale_block_total_sum(csr, block_cell_indices)
+    elif method == "median":
+        _centre_block_on_median(csr, block_cell_indices, add_block_median=True)
+    elif method == "median_center":
+        _centre_block_on_median(csr, block_cell_indices, add_block_median=False)
+
+
+def _rescale_block_total_sum(csr, block_cell_indices):
+    """total_sum: shift each row (a per-row additive shift on the log2 scale) so its linear total matches
+    the block's median row-total. nan-aware (``nansum``) to mirror the dense path; casting the shift to
+    the stored dtype keeps value-parity with it.
+    """
+    data = csr.data
+    row_totals = np.array([np.nansum(np.exp2(data[idx].astype(np.float64))) for idx in block_cell_indices])
+    block_log2_target = np.log2(np.median(row_totals))
+    for idx, row_total in zip(block_cell_indices, row_totals):
+        data[idx] = data[idx] + csr.dtype.type(block_log2_target - np.log2(row_total))
+
+
+def _centre_block_on_median(csr, block_cell_indices, add_block_median):
+    """median / median_center: subtract each row's median, then add the block-wide median of stored
+    values for "median" (0 for "median_center"). nan-aware (``nanmedian``) to mirror the dense path.
+    """
+    data = csr.data
+    if add_block_median:
+        block_median = np.nanmedian(np.concatenate([data[idx] for idx in block_cell_indices]))
     else:
-        global_median = csr.dtype.type(0)
-    for row in range(csr.shape[0]):
-        start, end = csr.indptr[row], csr.indptr[row + 1]
-        if end > start:
-            values = csr.data[start:end]
-            csr.data[start:end] = values - np.median(values) + global_median
-    return csr
-
-
-def _total_sum_normalise_per_sample_sparse(matrix):
-    """Per-sample total-intensity normalisation of a sparse block-diagonal, without densifying.
-
-    Mirrors the dense ``total_sum`` path: each obs row is rescaled so its summed intensity equals the
-    median of the per-sample totals. The input is assumed log2-transformed, so each row's total is
-    taken on the linear scale (``2 ** data``) and the rescale is applied as an additive shift on the
-    stored log2 values -- only ``.data`` is rewritten, so structurally-absent cells stay absent and the
-    result stays sparse. The stored dtype is preserved (the shift is cast to it) so values round
-    identically to the dense path. All-absent rows (no stored data) are left untouched and excluded
-    from the median, matching the dense path's all-NaN-row filter.
-    """
-    csr = matrix.tocsr(copy=True)
-    sample_totals = np.full(csr.shape[0], np.nan, dtype=np.float64)
-    for row in range(csr.shape[0]):
-        start, end = csr.indptr[row], csr.indptr[row + 1]
-        if end > start:
-            sample_totals[row] = np.exp2(csr.data[start:end].astype(np.float64)).sum()
-
-    log2_target_total = np.log2(np.nanmedian(sample_totals))
-    for row in range(csr.shape[0]):
-        start, end = csr.indptr[row], csr.indptr[row + 1]
-        if end > start:
-            per_sample_shift = log2_target_total - np.log2(sample_totals[row])
-            csr.data[start:end] = csr.data[start:end] + csr.dtype.type(per_sample_shift)
-    return csr
+        block_median = csr.dtype.type(0)
+    for idx in block_cell_indices:
+        values = data[idx]
+        data[idx] = values - np.nanmedian(values) + block_median
 
 
 def _normalise_by_groups(

--- a/tests/test_preprocessing_normalise_sparse.py
+++ b/tests/test_preprocessing_normalise_sparse.py
@@ -115,9 +115,11 @@ def test_sparse_layer_matches_dense(func, kwargs):
     )
 
 
-def test_scale_keeps_absent_cells_nan():
-    """scale densifies, but absent cells must stay NaN (not scaled from an imputed 0)."""
+def test_scale_re_sparsifies_and_keeps_absent_cells_nan():
+    """scale_data densifies for per-feature mean/std, then re-sparsifies a sparse input back to sparse;
+    absent cells stay NaN (never scaled from an imputed 0)."""
     out = scale_data(_make_sparse(), modality="psm", layer="raw")
+    assert sp.issparse(out["psm"].layers["raw"]), "scale_data should re-sparsify a sparse input"
     dense = to_dense_df(out["psm"], layer="raw").to_numpy()
     assert np.isnan(dense).sum() == _n_absent()
 
@@ -140,11 +142,12 @@ def test_normalise_per_sample_median_keeps_layer_sparse(method):
     assert np.isnan(to_dense_df(out["psm"], layer="raw").to_numpy()).sum() == _n_absent()
 
 
-def test_normalise_quantile_still_densifies():
-    """quantile is not sparse-native (per-sample rank mapping across differing blocks), so it falls
-    back to the NaN-aware densify path. Pins the intended boundary of the sparse fast-path."""
+def test_normalise_quantile_re_sparsifies():
+    """quantile densifies to compute (its per-sample rank mapping couples all samples), but a sparse
+    input is re-sparsified back to a sparse output -- absent cells dropped again."""
     out = normalise(_make_sparse(), method="quantile", modality="psm", layer="raw")
-    assert not sp.issparse(out["psm"].layers["raw"])
+    assert sp.issparse(out["psm"].layers["raw"]), "quantile should re-sparsify a sparse input"
+    assert np.isnan(to_dense_df(out["psm"], layer="raw").to_numpy()).sum() == _n_absent()
 
 
 def test_normalise_total_sum_keeps_layer_sparse():

--- a/tests/test_preprocessing_normalise_sparse.py
+++ b/tests/test_preprocessing_normalise_sparse.py
@@ -153,3 +153,65 @@ def test_normalise_total_sum_keeps_layer_sparse():
     out = normalise(_make_sparse(), method="total_sum", modality="psm", layer="raw")
     assert sp.issparse(out["psm"].layers["raw"]), "normalise(total_sum) densified the sparse block-diagonal"
     assert np.isnan(to_dense_df(out["psm"], layer="raw").to_numpy()).sum() == _n_absent()
+
+
+# obs "batch" and var "fraction" columns for grouped-normalisation tests. batch splits the 6 samples
+# into two groups; fraction puts v5 (mostly absent) in its own group so some (row, fraction) blocks are
+# all-absent and must be skipped -- exercising the block-skip path within a fraction.
+_BATCH = ["b1", "b1", "b2", "b2", "b1", "b2"]
+_FRACTION = ["f1", "f1", "f1", "f1", "f2"]
+
+
+def _mdata_grouped(layer_array) -> MuData:
+    adata = AnnData(
+        X=_DECOY_X.copy(),
+        obs=pd.DataFrame({"batch": _BATCH}, index=SAMPLES),
+        var=pd.DataFrame({"fraction": _FRACTION}, index=FEATURES),
+    )
+    adata.layers["raw"] = layer_array
+    return MuData({"psm": adata})
+
+
+@pytest.mark.parametrize("method", ["median", "median_center", "total_sum"])
+@pytest.mark.parametrize(
+    "group_kwargs",
+    [
+        {"batch_key": "batch"},
+        {"fraction_key": "fraction"},
+        {"batch_key": "batch", "fraction_key": "fraction"},
+    ],
+)
+def test_grouped_sparse_matches_dense(method, group_kwargs):
+    """Grouped (batch / fraction / both) per-sample normalisation on a sparse layer must equal the dense
+    result and stay sparse -- each (obs_group x var_group) block is rescaled in place, never densified."""
+    sparse_out = normalise(
+        _mdata_grouped(_sparse_with_absent_cells(_VALUES)), method=method, modality="psm", layer="raw", **group_kwargs
+    )
+    dense_out = normalise(_mdata_grouped(_VALUES.copy()), method=method, modality="psm", layer="raw", **group_kwargs)
+    assert sp.issparse(sparse_out["psm"].layers["raw"]), f"grouped normalise({method}) densified the sparse layer"
+    pd.testing.assert_frame_equal(
+        to_dense_df(sparse_out["psm"], layer="raw"),
+        to_dense_df(dense_out["psm"], layer="raw"),
+    )
+
+
+def test_grouped_normalise_actually_groups():
+    """Non-vacuity guard: fraction grouping must change the result vs ungrouped, so the parity test
+    cannot pass by both paths silently ignoring the grouping."""
+    grouped = to_dense_df(
+        normalise(
+            _mdata_grouped(_sparse_with_absent_cells(_VALUES)),
+            method="median",
+            modality="psm",
+            layer="raw",
+            fraction_key="fraction",
+        )["psm"],
+        layer="raw",
+    ).to_numpy()
+    ungrouped = to_dense_df(
+        normalise(_mdata_grouped(_sparse_with_absent_cells(_VALUES)), method="median", modality="psm", layer="raw")[
+            "psm"
+        ],
+        layer="raw",
+    ).to_numpy()
+    assert not np.allclose(grouped, ungrouped, equal_nan=True)


### PR DESCRIPTION
## Summary

Makes `normalise` and `scale_data` preserve the sparse block-diagonal layer end to end -- a sparse input now yields a sparse output for **every** method, including grouped normalisation.

### Grouped normalisation stays sparse (`55e916a`)

- `normalise(batch_key=... / fraction_key=...)` previously densified even for the per-sample methods (`median` / `median_center` / `total_sum`). Generalise the ungrouped per-sample sparse path to normalise each `(obs_group × var_group)` block in place: `_normalise_per_group_sparse` partitions rows/columns, and `_normalise_sparse_block` collects a block's stored cells and dispatches to `_rescale_block_total_sum` / `_centre_block_on_median`.
- The ungrouped case is the single-block special case, taken via a whole-row fast path, so the common path keeps its slice-based speed and value-parity with the dense path.
- The two dedicated ungrouped helpers are subsumed into this one path.
- Block reductions are nan-aware (`nanmedian` / `nansum`) to mirror the dense path.

### quantile / scale re-sparsify (`7785f65`)

- `quantile` (its per-sample rank mapping couples all samples) and `scale_data` (per-feature mean/std) must densify to compute, but they leave the observed-cell pattern unchanged. Re-sparsify their result via `to_observed_sparse` when the input was sparse, recovering the memory the densify spent on the absent cells. The compute peak is unchanged; the stored output shrinks by the missing fraction.
- quantile still computes on the densify path (it is intrinsically dense); it is just re-sparsified afterwards.

## Tests

- Grouped (batch / fraction / both) × (median / median_center / total_sum) sparse-vs-dense parity, including a single-feature fraction to exercise the block-skip path, plus a non-vacuity guard.
- `quantile` and `scale_data` now re-sparsify a sparse input (assertions flipped from "still densifies").
- Ungrouped parity unchanged (no regression).
- Full suite: **468 passed / 0 failed**, ruff clean.

## Notes

- Internal representation only; the public `normalise` / `scale_data` API is unchanged. Downstream consumers are already sparse-safe.
