### PR TITLE
refactor(preprocessing): own dense+sparse dispatch on Normalisation, rename grouping params (BID-132)

### DIFF
--- a/docs/how-it-works/normalization.md
+++ b/docs/how-it-works/normalization.md
@@ -17,7 +17,7 @@ mdata = mm.pp.log2_transform(
 
 ## `normalize()` (or `normalise()`)
 
-The `normalize()` function offers multiple normalization methods, including median (`median`), quantile (`quantile`), and total-intensity / constant-sum (`total_sum`) normalization. Users can select the method that best suits their data and experimental design. For fractionated TMT data, setting the `fraction` argument to `True` ensures that normalization is performed within each fraction separately.
+The `normalize()` function offers multiple normalization methods, including median (`median`), quantile (`quantile`), and total-intensity / constant-sum (`total_sum`) normalization. Users can select the method that best suits their data and experimental design. Normalization can also be performed independently within groups: pass `group_obs` (an `adata.obs` column, e.g. sample batch or type) and/or `group_var` (an `adata.var` column, e.g. `"filename"` for fractionated runs) to normalize within each group.
 
 `total_sum` rescales each sample so that its summed intensity equals the median of the per-sample totals, correcting sample-to-sample loading differences while leaving within-sample feature ratios unchanged. Because summing log values is meaningless, it computes each sample's total on the linear scale internally; like the other methods it assumes log2-transformed input.
 
@@ -26,7 +26,8 @@ mdata = mm.pp.normalize(
     mdata,
     modality="psm",           # or "peptide", "protein"
     method="median",          # options: "median", "quantile", "total_sum"; default "median"
-    fraction=False            # whether data is fractionated
+    group_obs=None,           # optional adata.obs column: normalize within each sample group
+    group_var=None,           # optional adata.var column (e.g. "filename"): normalize within each feature group
 )
 ```
 

--- a/docs/tutorials/dda-tmt.ipynb
+++ b/docs/tutorials/dda-tmt.ipynb
@@ -269,17 +269,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "f88f582d",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "mdata = mm.pp.log2_transform(mdata, modality=\"psm\")\n",
-    "mdata = mm.pp.normalize(mdata, modality=\"psm\", method=\"median\", fraction=True)\n",
-    "\n",
-    "# GIS-based scaling (if needed)\n",
-    "# mdata = mm.pp.correct_batch_effect(mdata=mdata, modality=\"psm\", method=\"gis\", gis_prefix=\"POOLED_\")"
-   ]
+   "source": "mdata = mm.pp.log2_transform(mdata, modality=\"psm\")\nmdata = mm.pp.normalize(mdata, modality=\"psm\", method=\"median\", group_var=\"filename\")\n\n# GIS-based scaling (if needed)\n# mdata = mm.pp.correct_batch_effect(mdata=mdata, modality=\"psm\", method=\"gis\", gis_prefix=\"POOLED_\")"
   },
   {
    "cell_type": "markdown",

--- a/docs/tutorials/dia-lfq.ipynb
+++ b/docs/tutorials/dia-lfq.ipynb
@@ -165,10 +165,7 @@
    "id": "d7394ea7",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "mdata = mm.pp.log2_transform(mdata, modality=\"psm\")\n",
-    "mdata = mm.pp.normalize(mdata, modality=\"psm\", method=\"median\", fraction=True)"
-   ]
+   "source": "mdata = mm.pp.log2_transform(mdata, modality=\"psm\")\nmdata = mm.pp.normalize(mdata, modality=\"psm\", method=\"median\", group_var=\"filename\")"
   },
   {
    "cell_type": "markdown",

--- a/msmu/_preprocessing/_normalisation.py
+++ b/msmu/_preprocessing/_normalisation.py
@@ -22,6 +22,7 @@ class Normalisation:
     def __init__(self, method: NormalisationMethod, axis: str) -> None:
         if method not in _NORMALISATION_METHODS:
             raise ValueError(f"Unknown normalisation method '{method}'. Choose from {_NORMALISATION_METHODS}.")
+        self._method = method
         self._method_call: Callable = getattr(self, f"_{method}")
         self._axis = axis
 
@@ -40,6 +41,44 @@ class Normalisation:
 
     def _total_sum(self, arr) -> np.ndarray:
         return normalise_total_sum(arr)
+
+    # Sparse per-block rescalers, mirroring the dense ``_{method}`` above. The obs/var partitioning and
+    # cell gathering live in ``_normalise._normalise_per_group_sparse``; these just rewrite the given
+    # block's stored ``.data`` in place, nan-aware to match the dense path. A method is sparse-native iff
+    # it defines ``_{method}_sparse`` -- quantile does not (its per-sample rank mapping couples all
+    # samples), so it densifies instead.
+    def _total_sum_sparse(self, csr, cell_indices) -> None:
+        data = csr.data
+        row_totals = np.array([np.nansum(np.exp2(data[idx].astype(np.float64))) for idx in cell_indices])
+        block_log2_target = np.log2(np.median(row_totals))
+        for idx, row_total in zip(cell_indices, row_totals):
+            data[idx] = data[idx] + csr.dtype.type(block_log2_target - np.log2(row_total))
+
+    def _median_sparse(self, csr, cell_indices) -> None:
+        self._centre_on_median_sparse(csr, cell_indices, add_block_median=True)
+
+    def _median_center_sparse(self, csr, cell_indices) -> None:
+        self._centre_on_median_sparse(csr, cell_indices, add_block_median=False)
+
+    @staticmethod
+    def _centre_on_median_sparse(csr, cell_indices, add_block_median: bool) -> None:
+        data = csr.data
+        if add_block_median:
+            block_median = np.nanmedian(np.concatenate([data[idx] for idx in cell_indices]))
+        else:
+            block_median = csr.dtype.type(0)
+        for idx in cell_indices:
+            values = data[idx]
+            data[idx] = values - np.nanmedian(values) + block_median
+
+    @property
+    def is_sparse_native(self) -> bool:
+        """Whether this method can be computed on the sparse block-diagonal without densifying."""
+        return hasattr(self, f"_{self._method}_sparse")
+
+    def rescale_sparse_block(self, csr, cell_indices) -> None:
+        """Rescale one block's stored cells in place, dispatching to this method's sparse rescaler."""
+        getattr(self, f"_{self._method}_sparse")(csr, cell_indices)
 
     def normalise(self, arr) -> np.ndarray:
         na_idx = np.isnan(arr)

--- a/msmu/_preprocessing/_normalise.py
+++ b/msmu/_preprocessing/_normalise.py
@@ -105,6 +105,8 @@ def normalise(
     method: NormalisationMethod,
     modality: str,
     layer: str | None = None,
+    group_obs: str | None = None,
+    group_var: str | None = None,
     batch_key: str | None = None,
     fraction_key: str | None = None,
     fraction: bool = False,
@@ -117,30 +119,38 @@ def normalise(
         method: Normalisation method to use. Options are 'quantile', 'median', 'total_sum'.
         modality: Modality to normalise.
         layer: Layer to normalise. If None, the default layer (.X) will be used.
-        batch_key: Column name in ``adata.obs`` defining batches. If provided, normalisation
-            is performed independently within each batch. If None, no batch grouping is applied.
-        fraction_key: Column name in ``adata.var`` defining fractions (e.g. ``"filename"`` for
-            fractionated TMT or fractionated label-free workflows). If provided, normalisation
-            is performed independently within each fraction. If None, no fraction grouping
-            is applied.
-        fraction: Deprecated. If True, equivalent to ``fraction_key="filename"``. Use
-            ``fraction_key`` instead.
+        group_obs: Column name in ``adata.obs`` defining sample groups. If provided, normalisation is
+            performed independently within each group. If None, no obs grouping is applied.
+        group_var: Column name in ``adata.var`` defining feature groups (e.g. ``"filename"`` for
+            fractionated TMT or label-free workflows). If provided, normalisation is performed
+            independently within each group. If None, no var grouping is applied.
+        batch_key: Deprecated alias for ``group_obs``.
+        fraction_key: Deprecated alias for ``group_var``.
+        fraction: Deprecated. If True, equivalent to ``group_var="filename"``.
 
     Returns:
         Normalised MuData object.
 
     Notes:
-        When both ``batch_key`` and ``fraction_key`` are provided, normalisation is performed
-        independently within each (batch × fraction) block.
+        When both ``group_obs`` and ``group_var`` are provided, normalisation is performed
+        independently within each (obs-group × var-group) block.
     """
+    if batch_key is not None:
+        warnings.warn("`batch_key` is deprecated; use `group_obs` instead.", DeprecationWarning, stacklevel=2)
+        if group_obs is None:
+            group_obs = batch_key
+    if fraction_key is not None:
+        warnings.warn("`fraction_key` is deprecated; use `group_var` instead.", DeprecationWarning, stacklevel=2)
+        if group_var is None:
+            group_var = fraction_key
     if fraction:
         warnings.warn(
-            "`fraction=True` is deprecated; pass `fraction_key='filename'` instead.",
+            "`fraction=True` is deprecated; use `group_var='filename'` instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        if fraction_key is None:
-            fraction_key = "filename"
+        if group_var is None:
+            group_var = "filename"
 
     axis: str = "obs"
 
@@ -153,21 +163,21 @@ def normalise(
     else:
         raw_arr: np.ndarray = adata.layers[layer]
 
-    if batch_key is not None and batch_key not in adata.obs.columns:
-        raise KeyError(f"batch_key '{batch_key}' not found in adata.obs of modality '{modality}'.")
-    if fraction_key is not None and fraction_key not in adata.var.columns:
-        raise KeyError(f"fraction_key '{fraction_key}' not found in adata.var of modality '{modality}'.")
+    if group_obs is not None and group_obs not in adata.obs.columns:
+        raise KeyError(f"group_obs '{group_obs}' not found in adata.obs of modality '{modality}'.")
+    if group_var is not None and group_var not in adata.var.columns:
+        raise KeyError(f"group_var '{group_var}' not found in adata.var of modality '{modality}'.")
 
-    obs_groups = adata.obs[batch_key].to_numpy() if batch_key is not None else None
-    var_groups = adata.var[fraction_key].to_numpy() if fraction_key is not None else None
+    obs_groups = adata.obs[group_obs].to_numpy() if group_obs is not None else None
+    var_groups = adata.var[group_var].to_numpy() if group_var is not None else None
 
-    # Per-sample normalisation (median / median_center / total_sum) is computable directly on the sparse
-    # block-diagonal -- each obs row is rescaled from its own stored values -- so it stays sparse instead
-    # of materialising the (samples x features) dense matrix, for the common ungrouped case as well as
-    # batch/fraction grouping (each block normalised independently). Quantile is not sparse-native (its
-    # per-sample rank mapping couples all samples), so it falls back to the NaN-aware densify path.
-    if is_sparse(raw_arr) and method in ("median", "median_center", "total_sum"):
-        normalised_arr = _normalise_per_group_sparse(raw_arr, obs_groups, var_groups, method)
+    # Sparse-native methods (those the ``Normalisation`` object defines a ``_{method}_sparse`` rescaler
+    # for) are computed directly on the sparse block-diagonal -- each obs row is rescaled from its own
+    # stored values -- so the layer stays sparse instead of materialising the dense matrix, for the
+    # common ungrouped case as well as grouped normalisation (each block normalised independently).
+    # Quantile is not sparse-native (its per-sample rank mapping couples all samples), so it densifies.
+    if is_sparse(raw_arr) and norm_cls.is_sparse_native:
+        normalised_arr = _normalise_per_group_sparse(raw_arr, obs_groups, var_groups, norm_cls)
     else:
         input_was_sparse = is_sparse(raw_arr)
         if input_was_sparse:
@@ -198,6 +208,8 @@ def normalize(
     method: NormalisationMethod,
     modality: str,
     layer: str | None = None,
+    group_obs: str | None = None,
+    group_var: str | None = None,
     batch_key: str | None = None,
     fraction_key: str | None = None,
     fraction: bool = False,
@@ -210,6 +222,8 @@ def normalize(
         method=method,
         modality=modality,
         layer=layer,
+        group_obs=group_obs,
+        group_var=group_var,
         batch_key=batch_key,
         fraction_key=fraction_key,
         fraction=fraction,
@@ -224,36 +238,34 @@ def _partition_indices(groups: np.ndarray | None, length: int) -> list[np.ndarra
     return [np.where(groups == group)[0] for group in unique_groups]
 
 
-def _normalise_per_group_sparse(matrix, obs_groups, var_groups, method):
+def _normalise_per_group_sparse(matrix, obs_groups, var_groups, norm_cls):
     """Per-sample normalisation of a sparse block-diagonal within each (obs_group x var_group) block,
     without densifying.
 
     Generalises the ungrouped per-sample path: with ``obs_groups`` and ``var_groups`` both None the
     whole matrix is a single block (the common PSM-level TMT/DIA case, taken via a whole-row fast
-    path). ``obs_groups`` (batch) partitions rows and ``var_groups`` (fraction) partitions columns;
-    each block is normalised independently, matching the dense ``_normalise_by_groups`` path. Only
-    ``.data`` is rewritten so structurally-absent cells stay absent and the layer stays sparse; the
-    stored dtype is preserved so values round identically to the dense path.
-
-    ``method`` is one of "median" / "median_center" / "total_sum" (quantile is not sparse-native).
+    path). ``obs_groups`` (obs grouping) partitions rows and ``var_groups`` (var grouping) partitions
+    columns; each block is normalised independently, matching the dense ``_normalise_by_groups`` path.
+    ``norm_cls`` supplies the per-block rescaler (``rescale_sparse_block``). Only ``.data`` is rewritten
+    so structurally-absent cells stay absent and the layer stays sparse; the stored dtype is preserved.
     """
     csr = matrix.tocsr(copy=True)
     row_partitions = _partition_indices(obs_groups, csr.shape[0])
     # A single ``None`` column-partition keeps the whole-row fast path (no per-row column split) when
-    # no fraction grouping is requested -- covers the hot ungrouped case and batch-only grouping.
+    # no var grouping is requested -- covers the hot ungrouped case and obs-only grouping.
     col_partitions = _partition_indices(var_groups, csr.shape[1]) if var_groups is not None else [None]
     for row_indices in row_partitions:
         for col_indices in col_partitions:
-            _normalise_sparse_block(csr, row_indices, col_indices, method)
+            _normalise_sparse_block(csr, row_indices, col_indices, norm_cls)
     return csr
 
 
-def _normalise_sparse_block(csr, row_indices, col_indices, method):
-    """Collect the stored-cell indices of one (row_indices x col_indices) block, then dispatch to the
-    method's in-place rescaler. ``col_indices=None`` means all columns (whole-row slices -- the hot path,
-    no per-row column split). Rows with no stored cell in the block are skipped and excluded from the
-    block scalar, matching the dense path's all-NaN-row filter. Only stored cells are touched, so absent
-    cells stay absent and the stored dtype is preserved.
+def _normalise_sparse_block(csr, row_indices, col_indices, norm_cls):
+    """Collect the stored-cell indices of one (row_indices x col_indices) block, then hand them to
+    ``norm_cls.rescale_sparse_block`` to rewrite in place. ``col_indices=None`` means all columns
+    (whole-row slices -- the hot path, no per-row column split). Rows with no stored cell in the block
+    are skipped and excluded from the block scalar, matching the dense path's all-NaN-row filter. Only
+    stored cells are touched, so absent cells stay absent and the stored dtype is preserved.
     """
     indptr, indices = csr.indptr, csr.indices
     column_mask = None
@@ -262,7 +274,7 @@ def _normalise_sparse_block(csr, row_indices, col_indices, method):
         column_mask[col_indices] = True
 
     # Per-row index into ``csr.data`` for this block's cells: a contiguous slice for the whole-row path,
-    # or an explicit position array when a fraction column mask restricts the row.
+    # or an explicit position array when a var-group column mask restricts the row.
     block_cell_indices: list = []
     for row in row_indices:
         start, end = indptr[row], indptr[row + 1]
@@ -274,41 +286,8 @@ def _normalise_sparse_block(csr, row_indices, col_indices, method):
             selected = np.nonzero(column_mask[indices[start:end]])[0]
             if selected.size:
                 block_cell_indices.append(start + selected)
-    if not block_cell_indices:
-        return
-
-    if method == "total_sum":
-        _rescale_block_total_sum(csr, block_cell_indices)
-    elif method == "median":
-        _centre_block_on_median(csr, block_cell_indices, add_block_median=True)
-    elif method == "median_center":
-        _centre_block_on_median(csr, block_cell_indices, add_block_median=False)
-
-
-def _rescale_block_total_sum(csr, block_cell_indices):
-    """total_sum: shift each row (a per-row additive shift on the log2 scale) so its linear total matches
-    the block's median row-total. nan-aware (``nansum``) to mirror the dense path; casting the shift to
-    the stored dtype keeps value-parity with it.
-    """
-    data = csr.data
-    row_totals = np.array([np.nansum(np.exp2(data[idx].astype(np.float64))) for idx in block_cell_indices])
-    block_log2_target = np.log2(np.median(row_totals))
-    for idx, row_total in zip(block_cell_indices, row_totals):
-        data[idx] = data[idx] + csr.dtype.type(block_log2_target - np.log2(row_total))
-
-
-def _centre_block_on_median(csr, block_cell_indices, add_block_median):
-    """median / median_center: subtract each row's median, then add the block-wide median of stored
-    values for "median" (0 for "median_center"). nan-aware (``nanmedian``) to mirror the dense path.
-    """
-    data = csr.data
-    if add_block_median:
-        block_median = np.nanmedian(np.concatenate([data[idx] for idx in block_cell_indices]))
-    else:
-        block_median = csr.dtype.type(0)
-    for idx in block_cell_indices:
-        values = data[idx]
-        data[idx] = values - np.nanmedian(values) + block_median
+    if block_cell_indices:
+        norm_cls.rescale_sparse_block(csr, block_cell_indices)
 
 
 def _normalise_by_groups(

--- a/tests/test_preprocessing_normalise.py
+++ b/tests/test_preprocessing_normalise.py
@@ -33,61 +33,61 @@ def test_normalise_median(simple_mdata):
     assert out["psm"].X.shape == (6, 2)
 
 
-def test_normalise_batch_key_groups_within_batch(mdata):
-    """median centering within batches should zero each sample's median within its batch block."""
-    out = normalise(mdata, method="median_center", modality="psm", batch_key="batch")
+def test_normalise_group_obs_groups_within_group(mdata):
+    """median centering within obs groups should zero each sample's median within its group block."""
+    out = normalise(mdata, method="median_center", modality="psm", group_obs="batch")
     arr = out["psm"].X
     # mdata: batch="x" → obs rows [0, 2], batch="y" → obs rows [1, 3]
-    for batch_rows in ([0, 2], [1, 3]):
-        block = arr[batch_rows, :]
+    for group_rows in ([0, 2], [1, 3]):
+        block = arr[group_rows, :]
         row_medians = np.nanmedian(block, axis=1)
         assert np.allclose(row_medians[~np.isnan(row_medians)], 0.0)
 
 
-def test_normalise_batch_key_invalid_raises(mdata):
-    with pytest.raises(KeyError, match="batch_key"):
-        normalise(mdata, method="median", modality="psm", batch_key="nonexistent")
+def test_normalise_group_obs_invalid_raises(mdata):
+    with pytest.raises(KeyError, match="group_obs"):
+        normalise(mdata, method="median", modality="psm", group_obs="nonexistent")
 
 
-def test_normalise_fraction_key_invalid_raises(mdata):
-    with pytest.raises(KeyError, match="fraction_key"):
-        normalise(mdata, method="median", modality="psm", fraction_key="nonexistent")
+def test_normalise_group_var_invalid_raises(mdata):
+    with pytest.raises(KeyError, match="group_var"):
+        normalise(mdata, method="median", modality="psm", group_var="nonexistent")
 
 
-def test_normalise_fraction_bool_emits_deprecation_warning(mdata):
+def test_normalise_group_obs_and_group_var_combined(mdata):
+    """Both grouping keys together: normalise within each (obs-group × var-group) block."""
     mdata.mod["psm"].var["filename"] = ["f1", "f2", "f1"]
-    with pytest.warns(DeprecationWarning, match="fraction"):
-        normalise(mdata, method="median_center", modality="psm", fraction=True)
-
-
-def test_normalise_fraction_key_matches_legacy_fraction(mdata):
-    mdata.mod["psm"].var["filename"] = ["f1", "f2", "f1"]
-    new_out = normalise(mdata, method="median_center", modality="psm", fraction_key="filename")
-    with pytest.warns(DeprecationWarning):
-        legacy_out = normalise(mdata, method="median_center", modality="psm", fraction=True)
-    assert np.allclose(new_out["psm"].X, legacy_out["psm"].X, equal_nan=True)
-
-
-def test_normalise_batch_and_fraction_combined(mdata):
-    """Both grouping keys together: normalise within each (batch × fraction) block."""
-    mdata.mod["psm"].var["filename"] = ["f1", "f2", "f1"]
-    out = normalise(
-        mdata,
-        method="median_center",
-        modality="psm",
-        batch_key="batch",
-        fraction_key="filename",
-    )
+    out = normalise(mdata, method="median_center", modality="psm", group_obs="batch", group_var="filename")
     arr = out["psm"].X
-    # batches: "x" → obs rows [0, 2]; "y" → obs rows [1, 3]
-    # fractions: "f1" → var cols [0, 2]; "f2" → var col [1]
-    # axis="obs" normalises per-sample, so each row's median within each block should be 0
-    for obs_idx, var_idx in [
-        ([0, 2], [0, 2]),
-        ([0, 2], [1]),
-        ([1, 3], [0, 2]),
-        ([1, 3], [1]),
-    ]:
+    # obs groups: "x" → rows [0, 2]; "y" → rows [1, 3]. var groups: "f1" → cols [0, 2]; "f2" → col [1].
+    # axis="obs" normalises per-sample, so each row's median within each block should be 0.
+    for obs_idx, var_idx in [([0, 2], [0, 2]), ([0, 2], [1]), ([1, 3], [0, 2]), ([1, 3], [1])]:
         block = arr[np.ix_(obs_idx, var_idx)]
         row_medians = np.nanmedian(block, axis=1)
         assert np.allclose(row_medians[~np.isnan(row_medians)], 0.0)
+
+
+# ---- deprecated aliases: still work, but warn and map to the new names ----
+
+
+def test_normalise_batch_key_is_deprecated_alias_for_group_obs(mdata):
+    with pytest.warns(DeprecationWarning, match="batch_key"):
+        legacy = normalise(mdata, method="median_center", modality="psm", batch_key="batch")
+    current = normalise(mdata, method="median_center", modality="psm", group_obs="batch")
+    assert np.allclose(legacy["psm"].X, current["psm"].X, equal_nan=True)
+
+
+def test_normalise_fraction_key_is_deprecated_alias_for_group_var(mdata):
+    mdata.mod["psm"].var["filename"] = ["f1", "f2", "f1"]
+    with pytest.warns(DeprecationWarning, match="fraction_key"):
+        legacy = normalise(mdata, method="median_center", modality="psm", fraction_key="filename")
+    current = normalise(mdata, method="median_center", modality="psm", group_var="filename")
+    assert np.allclose(legacy["psm"].X, current["psm"].X, equal_nan=True)
+
+
+def test_normalise_fraction_bool_deprecated_and_maps_to_group_var_filename(mdata):
+    mdata.mod["psm"].var["filename"] = ["f1", "f2", "f1"]
+    with pytest.warns(DeprecationWarning, match="fraction"):
+        legacy = normalise(mdata, method="median_center", modality="psm", fraction=True)
+    current = normalise(mdata, method="median_center", modality="psm", group_var="filename")
+    assert np.allclose(legacy["psm"].X, current["psm"].X, equal_nan=True)

--- a/tests/test_preprocessing_normalise_sparse.py
+++ b/tests/test_preprocessing_normalise_sparse.py
@@ -179,9 +179,9 @@ def _mdata_grouped(layer_array) -> MuData:
 @pytest.mark.parametrize(
     "group_kwargs",
     [
-        {"batch_key": "batch"},
-        {"fraction_key": "fraction"},
-        {"batch_key": "batch", "fraction_key": "fraction"},
+        {"group_obs": "batch"},
+        {"group_var": "fraction"},
+        {"group_obs": "batch", "group_var": "fraction"},
     ],
 )
 def test_grouped_sparse_matches_dense(method, group_kwargs):
@@ -207,7 +207,7 @@ def test_grouped_normalise_actually_groups():
             method="median",
             modality="psm",
             layer="raw",
-            fraction_key="fraction",
+            group_var="fraction",
         )["psm"],
         layer="raw",
     ).to_numpy()


### PR DESCRIPTION
## Summary

Two related normalisation cleanups.

### Part A — dispatch owned by the Normalisation object

The `Normalisation` object now owns each method's sparse per-block rescaler (`_{method}_sparse`) alongside its dense `_{method}`, and exposes `is_sparse_native` and `rescale_sparse_block`. The `normalise` orchestrator and the sparse block machinery dispatch through the object (`if is_sparse and norm_cls.is_sparse_native`, `norm_cls.rescale_sparse_block(...)`) instead of hardcoding the sparse-native method set in two places. A method's dense + sparse behaviour now lives in one place — adding a sparse-native method is a single `_{method}_sparse` on the class.

The block-rescale helpers (`_rescale_block_total_sum` / `_centre_block_on_median`) move onto the object as `_total_sum_sparse` / `_median_sparse` / `_median_center_sparse` (sharing `_centre_on_median_sparse`). The method-agnostic partition/gather machinery (`_normalise_per_group_sparse` / `_normalise_sparse_block`) stays in `_normalise.py` alongside its dense sibling `_normalise_by_groups`.

### Part B — rename grouping parameters

`batch_key` → `group_obs` and `fraction_key` → `group_var` on `normalise` / `normalize`. These normalise within an `adata.obs` / `adata.var` column group (not batch correction; `fraction=True` was just `group_var="filename"`). The old names and `fraction=True` are kept as **deprecated aliases** that emit a `DeprecationWarning` and map to the new names.

## Tests

- Grouping tests use `group_obs` / `group_var`; added deprecation-alias tests (old names still work + warn).
- Behaviour-preserving: the sparse==dense parity and grouping tests are the safety net.
- Full suite: **469 passed / 0 failed**, ruff clean.

## Notes

- Public API: `group_obs` / `group_var` are the new names; `batch_key` / `fraction_key` / `fraction` remain as deprecated aliases. Docs (`normalization.md`) and the DIA / TMT tutorials updated.
