### PR TITLE
[BID-128] Clarify batch-correction scale-restore logging (no-reference GIS drops reported at correction)

### DIFF
--- a/msmu/_preprocessing/_batch_correction.py
+++ b/msmu/_preprocessing/_batch_correction.py
@@ -154,7 +154,18 @@ class BatchCorrector:
                 reference_target = np.nanmean(gis_avg_arr, axis=0)
             else:
                 reference_target = np.exp(np.nanmean(np.log(gis_avg_arr), axis=0))
-        restore_mask = self._restore_mask(np.sum(~np.isnan(gis_avg_arr), axis=0))
+        reference_batch_count = np.sum(~np.isnan(gis_avg_arr), axis=0)
+        n_missing_reference = int((reference_batch_count == 0).sum())
+        if n_missing_reference:
+            # A feature with no GIS channel in any batch has no reference to normalise against; the
+            # correction below subtracts NaN and it becomes NaN (dropped). Reported here (at the
+            # correction) rather than at the restore, where it would look like a scale choice.
+            logger.warning(
+                "%d/%d features have no GIS reference in any batch; they become NaN after correction.",
+                n_missing_reference,
+                reference_batch_count.size,
+            )
+        restore_mask = self._restore_mask(reference_batch_count)
 
         correction_factor = gis_avg_arr[batch_idx, :]
         self.corrected_arr = self._correct(correction_factor=correction_factor)
@@ -303,14 +314,14 @@ class BatchCorrector:
         are restored is decided by :meth:`_restore_mask`.
         """
         n_restored = int(restore_mask.sum())
-        logger.info(
-            "Restoring per-feature scale for %d/%d features (%d left reference-relative).",
-            n_restored,
-            restore_mask.size,
-            restore_mask.size - n_restored,
-        )
         if n_restored == 0:
+            logger.info(
+                "Fully block-diagonal (no feature spans >=%d batches): abundance scale not restored, "
+                "output stays reference-relative -- roll up before restoring the scale.",
+                MIN_BATCHES_FOR_SCALE_RESTORE,
+            )
             return
+        logger.info("Restored the abundance scale for %d/%d features.", n_restored, restore_mask.size)
         if self.log_transformed:
             self.corrected_arr[:, restore_mask] += reference_target[restore_mask]
         else:

--- a/tests/test_preprocessing_correct_batch.py
+++ b/tests/test_preprocessing_correct_batch.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 import numpy as np
 import pandas as pd
@@ -255,3 +257,49 @@ def test_correct_batch_effect_continuous(simple_mdata):
         log_transformed=True,
     )
     assert out["psm"].X.shape == (6, 2)
+
+
+def test_correct_batch_effect_gis_no_reference_feature_dropped(caplog):
+    # v2 has NO GIS reference in any batch (gis1/gis2 are NaN for it) though s1/s2 carry values, so
+    # the correction subtracts a missing reference and v2 becomes NaN -- reported at the correction
+    # as a warning, not as a restore "reference-relative" scale choice. v1 (reference in both) is
+    # restored normally.
+    x = np.array(
+        [
+            [1.0, 5.0],  # s1   (b1)
+            [4.0, np.nan],  # gis1 (b1 reference; v2 unobserved)
+            [5.0, 6.0],  # s2   (b2)
+            [12.0, np.nan],  # gis2 (b2 reference; v2 unobserved)
+        ]
+    )
+    mdata = _mdata_with_batch(x, ["s1", "gis1", "s2", "gis2"], ["v1", "v2"], ["b1", "b1", "b2", "b2"])
+
+    # The package logger does not propagate, so attach caplog's handler directly to capture the warning.
+    batch_logger = logging.getLogger("msmu._preprocessing._batch_correction")
+    batch_logger.addHandler(caplog.handler)
+    previous_level = batch_logger.level
+    batch_logger.setLevel(logging.WARNING)
+    try:
+        out = correct_batch_effect(
+            mdata,
+            modality="psm",
+            method="gis",
+            category="batch",
+            gis_samples=["gis1", "gis2"],
+            drop_gis=False,
+        )
+    finally:
+        batch_logger.removeHandler(caplog.handler)
+        batch_logger.setLevel(previous_level)
+
+    # v1 restored to target 8 (mean of 4, 12); v2 has no reference in any batch -> all NaN.
+    expected = np.array(
+        [
+            [5.0, np.nan],
+            [8.0, np.nan],
+            [1.0, np.nan],
+            [8.0, np.nan],
+        ]
+    )
+    np.testing.assert_allclose(out["psm"].X, expected, equal_nan=True)
+    assert "no GIS reference" in caplog.text


### PR DESCRIPTION
## Summary

Logging-only change (no behaviour change) to `correct_batch_effect`.

The single `_restore_scale` log conflated two very different "not restored" cases:
- a **fully block-diagonal** matrix (genuinely left reference-relative, ready to roll up), and
- on a **shared** matrix, features with **no observed reference in any batch** — which for GIS are dropped to NaN at the *correction* step (subtracting a missing reference), not "reference-relative".

At peptide-level GIS this surfaced as `436580/436841 (261 left reference-relative)`, where the 261 are peptides with no GIS reference that were actually dropped to NaN.

## Change

Split the logging so each step reports its own story:
- **`gis()`**: warns, at the correction, how many features have no GIS reference in any batch and become NaN.
- **`_restore_scale()`**: reports only the restored count, with a distinct message for the fully block-diagonal (nothing-restored) case. Drops the misleading "N left reference-relative" on shared matrices.

## Testing

- Added `test_correct_batch_effect_gis_no_reference_feature_dropped`: a feature with no GIS reference → NaN in output (dropped), a feature with a reference → restored; also asserts the "no GIS reference" warning.
- Full unit suite: **467 passed**, ruff clean.

Follow-up to BID-119 (#15).
