### PR TITLE
feat(preprocessing): re-sparsify batch-correction output for NaN-preserving methods (BID-133)

### DIFF
--- a/msmu/_preprocessing/_batch_correction.py
+++ b/msmu/_preprocessing/_batch_correction.py
@@ -8,10 +8,15 @@ from inmoose.pycombat import pycombat_norm
 
 from .._utils._mudata import get_anndata_mod, get_mudata
 from .._core._provenance import uns_logger
-from .._core._blockdiag import dense_block, is_sparse
+from .._core._blockdiag import dense_block, is_sparse, to_observed_sparse
 from ..logging_utils import get_logger
 
 logger = get_logger(__name__)
+
+# Methods that apply their correction subtractively/multiplicatively (via ``_correct``), so a sparse
+# input keeps its absent-cell (NaN) pattern and can be re-sparsified on the way out. ComBat replaces
+# the whole array (pycombat may fill NaN), so it is excluded and stays dense.
+_NAN_PRESERVING_METHODS: tuple[str, ...] = ("gis", "median_center", "continuous")
 
 # A matrix has cross-batch structure once at least one feature is observed in this many batches (a
 # cross-batch reference then exists). If NO feature reaches it the matrix is fully block-diagonal
@@ -60,6 +65,10 @@ def correct_batch_effect(
         Batch corrected MuData object.
     """
     mdata = mdata.copy()
+    adata = get_anndata_mod(mdata, modality)
+    input_arr = adata.X if layer is None else adata.layers[layer]
+    input_was_sparse = is_sparse(input_arr)
+    input_dtype = input_arr.dtype if input_was_sparse else None
 
     batch_corrector: BatchCorrector = BatchCorrector(
         mdata=mdata,
@@ -93,7 +102,12 @@ def correct_batch_effect(
         corrected_arr.shape,
     )
 
-    adata = get_anndata_mod(mdata, modality)
+    # gis / median_center / continuous apply their correction subtractively (``_correct``), so a sparse
+    # input keeps its absent-cell pattern -- re-sparsify to recover the memory the densify spent. ComBat
+    # replaces the whole array (may fill NaN), so it stays dense.
+    if input_was_sparse and method in _NAN_PRESERVING_METHODS:
+        corrected_arr = to_observed_sparse(corrected_arr, dtype=input_dtype)
+
     if layer is None:
         adata.X = corrected_arr
     else:

--- a/tests/test_preprocessing_correct_batch.py
+++ b/tests/test_preprocessing_correct_batch.py
@@ -3,9 +3,11 @@ import logging
 import pytest
 import numpy as np
 import pandas as pd
+import scipy.sparse as sp
 from anndata import AnnData
 from mudata import MuData
 
+from msmu._core._blockdiag import to_dense_df, to_observed_sparse
 from msmu._preprocessing._batch_correction import correct_batch_effect
 
 
@@ -303,3 +305,49 @@ def test_correct_batch_effect_gis_no_reference_feature_dropped(caplog):
     )
     np.testing.assert_allclose(out["psm"].X, expected, equal_nan=True)
     assert "no GIS reference" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "method, extra_kwargs",
+    [
+        ("gis", {"gis_samples": ["gis1", "gis2"], "drop_gis": False}),
+        ("median_center", {}),
+    ],
+)
+def test_correct_batch_effect_sparse_matches_dense_and_stays_sparse(method, extra_kwargs):
+    """gis / median_center apply the correction subtractively, so a sparse input must yield a sparse
+    output equal to the dense result (absent cells preserved, never densified out)."""
+    x = np.array(
+        [
+            [1.0, 10.0],  # s1   (b1)
+            [4.0, 8.0],  # gis1 (b1 reference)
+            [5.0, 20.0],  # s2   (b2)
+            [12.0, np.nan],  # gis2 (b2 reference; v2 unobserved)
+        ]
+    )
+    obs_names, var_names, batch = ["s1", "gis1", "s2", "gis2"], ["v1", "v2"], ["b1", "b1", "b2", "b2"]
+
+    dense_out = correct_batch_effect(
+        _mdata_with_batch(x, obs_names, var_names, batch), modality="psm", method=method, category="batch", **extra_kwargs
+    )
+    sparse_out = correct_batch_effect(
+        _mdata_with_batch(to_observed_sparse(x, dtype=np.float64), obs_names, var_names, batch),
+        modality="psm",
+        method=method,
+        category="batch",
+        **extra_kwargs,
+    )
+
+    assert sp.issparse(sparse_out["psm"].X), f"{method} should re-sparsify a sparse input"
+    np.testing.assert_allclose(
+        to_dense_df(sparse_out["psm"]).to_numpy(), to_dense_df(dense_out["psm"]).to_numpy(), equal_nan=True
+    )
+
+
+def test_correct_batch_effect_combat_densifies_sparse_input(simple_mdata):
+    """ComBat replaces the whole array (may fill NaN), so it is excluded from re-sparsify: a sparse
+    input yields a dense output. Pins the intended boundary."""
+    mdata = simple_mdata.copy()
+    mdata.mod["psm"].X = to_observed_sparse(np.asarray(mdata.mod["psm"].X, dtype=np.float64))
+    out = correct_batch_effect(mdata, modality="psm", method="combat", category="batch", log_transformed=True)
+    assert not sp.issparse(out["psm"].X)


### PR DESCRIPTION
## Summary

`correct_batch_effect` densifies a sparse input to compute (in `BatchCorrector`) and previously returned dense — the last sparse-in → dense-out step after `normalise` / `scale_data` were made sparse-preserving. This makes it sparse-in → sparse-out for the methods that keep the observed-cell pattern.

- **gis / median_center / continuous** apply their correction subtractively / multiplicatively (via `_correct`), so absent cells stay NaN. Their output is re-sparsified via `to_observed_sparse` when the input was sparse, recovering the memory the densify spent. The realistic case is **PSM-level GIS** (documented as a memory cost in the batch-restore work).
- **ComBat** is excluded (`_NAN_PRESERVING_METHODS`): it replaces the whole array (`corrected_arr = pycombat_output`), which may fill NaN, so it stays dense. In practice ComBat / continuous run on dense peptide/protein data anyway (they need shared features / a per-feature run-order trend, which a block-diagonal PSM matrix does not have).

## Tests

- gis / median_center on a sparse input: output is sparse and equals the dense result (absent cells preserved).
- ComBat on a sparse input stays dense (boundary pinned).
- Full suite: **473 passed / 0 failed**, ruff clean.

## Notes

- Internal representation only; the `correct_batch_effect` API is unchanged. Downstream consumers are already sparse-safe.
