### PR TITLE
fix(io): fill existing peptide modality in add_quant instead of overwriting

### DIFF
--- a/msmu/_read_write/_import.py
+++ b/msmu/_read_write/_import.py
@@ -5,7 +5,7 @@ import mudata as md
 import numpy as np
 import pandas as pd
 
-from .._utils._mudata import add_modality
+from .._utils._mudata import add_modality, get_anndata_mod
 from ..logging_utils import get_logger
 
 logger = get_logger(__name__)
@@ -69,14 +69,29 @@ def add_quant(
 
     input_arr = input_arr.loc[:, col_order]
     input_arr = input_arr.dropna(how="all")
+    # msmu stores .X as float32 (the readers do the same); casting on ingest keeps the peptide
+    # quantification float32 whether add_quant creates the modality or fills an existing one.
+    input_arr = input_arr.astype(np.float32)
 
-    peptide_adata = ad.AnnData(X=input_arr.T)
-    peptide_adata.uns["level"] = "peptide"
-
-    mdata = add_modality(mdata=mdata, adata=peptide_adata, mod_name="peptide")
-
-    logger.info("Added quantification modality 'peptide' using %s data.", quant_tool)
-    logger.debug("Added peptide quantification matrix with shape %s.", input_arr.shape)
+    if "peptide" in mdata.mod:
+        # A peptide identification layer already exists (e.g. to_peptide was run before
+        # add_quant). Preserve its var/uns -- protein mapping, q-values, decoy -- and only
+        # fill the quantification matrix, aligning FlashLFQ intensities onto the existing
+        # peptide (var) and sample (obs) axes. Peptides identified but not quantified by
+        # FlashLFQ stay NaN; peptides quantified by FlashLFQ but absent from the
+        # identification set are dropped. This is the same left-join to_peptide performs
+        # when quantification is attached first, so both call orders converge on one result.
+        peptide_adata = get_anndata_mod(mdata, "peptide")
+        aligned = input_arr.reindex(index=peptide_adata.var_names, columns=peptide_adata.obs_names)
+        peptide_adata.X = aligned.T.to_numpy()
+        logger.info("Filled existing peptide modality with %s quantification.", quant_tool)
+        logger.debug("Filled peptide quantification matrix with shape %s.", aligned.T.shape)
+    else:
+        peptide_adata = ad.AnnData(X=input_arr.T)
+        peptide_adata.uns["level"] = "peptide"
+        mdata = add_modality(mdata=mdata, adata=peptide_adata, mod_name="peptide")
+        logger.info("Added quantification modality 'peptide' using %s data.", quant_tool)
+        logger.debug("Added peptide quantification matrix with shape %s.", input_arr.shape)
 
     mdata.update_obs()
 

--- a/tests/test_read_write_import.py
+++ b/tests/test_read_write_import.py
@@ -1,11 +1,30 @@
 from pathlib import Path
 
+import anndata as ad
+import mudata as md
 import numpy as np
 import pandas as pd
 import pytest
 
 from msmu import io as msmu_io
 import msmu._utils as msmu_utils
+
+
+def _identification_only_peptide_mdata() -> md.MuData:
+    """A peptide modality carrying identifications but no quant (the state to_peptide leaves
+    behind when it runs before add_quant on label-free data). ``CC`` is identified but will
+    not be quantified by FlashLFQ."""
+    peptide = ad.AnnData(
+        X=np.full((3, 3), np.nan, dtype=np.float64),
+        obs=pd.DataFrame(index=["s1", "s2", "gis1"]),
+        var=pd.DataFrame(
+            {"proteins": ["P1", "P2", "P3"], "q_value": [0.001, 0.002, 0.02]},
+            index=["AA", "BB", "CC"],
+        ),
+    )
+    peptide.uns["level"] = "peptide"
+    peptide.uns["decoy"] = pd.DataFrame({"score": [9.0]}, index=["DECOY1"])
+    return md.MuData({"peptide": peptide})
 
 
 def test_add_quant_flashlfq_file_adds_peptide_modality(labeled_mdata):
@@ -36,3 +55,54 @@ def test_add_quant_flashlfq_requires_sequence_column(labeled_mdata):
 
     with pytest.raises(ValueError, match="Sequence"):
         msmu_io.add_quant(labeled_mdata, quant_data=quant, quant_tool="flashlfq")
+
+
+def test_add_quant_fills_existing_peptide_modality_and_preserves_identification():
+    # Regression (BID-134): when a peptide identification layer already exists (to_peptide ran
+    # before add_quant), add_quant must NOT overwrite it. It fills quant aligned onto the
+    # existing peptide/sample axes while keeping var (proteins, q_value) and uns (decoy).
+    mdata = _identification_only_peptide_mdata()
+    quant = pd.DataFrame(
+        {
+            "Sequence": ["AA", "BB", "ZZ"],  # ZZ is quantified but not identified -> dropped
+            "Intensity_s1": [1000.0, 3000.0, 7000.0],
+            "Intensity_s2": [2000.0, 5000.0, 8000.0],
+            "Intensity_gis1": [0.0, 4.0, 9.0],  # 0 -> NaN
+        }
+    )
+
+    out = msmu_io.add_quant(mdata, quant_data=quant, quant_tool="flashlfq")
+    peptide = out["peptide"]
+
+    # identification metadata survives untouched
+    assert list(peptide.var.columns) == ["proteins", "q_value"]
+    assert list(peptide.var["proteins"]) == ["P1", "P2", "P3"]
+    assert peptide.uns["level"] == "peptide"
+    assert "decoy" in peptide.uns
+
+    # peptide axis is the identification set: CC kept (identified), ZZ dropped (not identified)
+    assert list(peptide.var_names) == ["AA", "BB", "CC"]
+
+    # quant is ingested as float32 (msmu .X convention) regardless of the container's prior dtype
+    assert peptide.X.dtype == np.float32
+
+    # quant filled by sequence+sample; identified-but-unquantified stays NaN
+    df = peptide.to_df()
+    assert df.loc["s1", "AA"] == pytest.approx(1000.0)
+    assert df.loc["s2", "BB"] == pytest.approx(5000.0)
+    assert df.loc["gis1", "BB"] == pytest.approx(4.0)
+    assert np.isnan(df.loc["gis1", "AA"])  # 0 intensity -> NaN
+    assert bool(np.isnan(df.loc[:, "CC"]).all())  # CC identified but not quantified
+
+
+def test_add_quant_does_not_wipe_identification_var_regression():
+    # The original bug produced an empty var (add_modality overwrote the whole modality).
+    mdata = _identification_only_peptide_mdata()
+    quant = pd.DataFrame(
+        {"Sequence": ["AA"], "Intensity_s1": [1.0], "Intensity_s2": [2.0], "Intensity_gis1": [3.0]}
+    )
+
+    out = msmu_io.add_quant(mdata, quant_data=quant, quant_tool="flashlfq")
+
+    assert out["peptide"].var.shape[1] > 0
+    assert "q_value" in out["peptide"].var.columns


### PR DESCRIPTION
## Summary

`add_quant` (the FlashLFQ importer) overwrote an existing `peptide` modality via `add_modality`, so calling it **after** `to_peptide` wiped the peptide identification layer — `var` (`peptide`, `proteins`, `q_value`, ...) and `uns.decoy` — leaving only the bare intensity matrix. Downstream `to_protein`/DE then had no identifications to work with.

`add_quant` now detects an existing `peptide` modality and **fills** quantification aligned onto its peptide (`var`) and sample (`obs`) axes, preserving `var`/`uns`. This is the same left-join `to_peptide` performs when quant is attached first, so both call orders converge on one result:

- `to_peptide` → `add_quant` (the order the FlashLFQ tutorial uses)
- `add_quant` → `to_peptide`

FlashLFQ intensities are also cast to **float32** on ingest (msmu's `.X` convention, matching the readers), so the two orders produce a **bit-identical** result rather than diverging on dtype (float64 vs float32).

## Behavior

- Peptides identified but not quantified by FlashLFQ → `NaN`.
- Peptides quantified by FlashLFQ but absent from the identification set → dropped.
- If no `peptide` modality exists yet, the original create path is unchanged.
- `add_modality` is untouched — no impact on `to_protein`/`to_ptm`.

## Verification

- **Real data** (Sage LFQ + `QuantifiedPeptides.tsv`): both orders bit-identical — `var` 6 cols + `uns.decoy` preserved, quant equal via `np.array_equal(equal_nan)`, both `float32`.
- **New regression tests**: aligned fill (identified-not-quantified → NaN, quantified-not-identified → dropped), `var`/`uns` preservation, no-overwrite regression, `float32` dtype.
- Touched suites (import / export / summarisation / tmt + FlashLFQ tutorial) green; `ruff` clean.

Ticket: BID-134
