### PR TITLE
fix(preprocessing): handle categorical var columns from h5mu round-trips (BID-160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `msmu` are documented in this file. The format is based o
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Release versions are derived
 from git tags via setuptools-scm.
 
+## [0.3.1] - 2026-08-11
+
+### Fixed
+
+- **Protein groups were destroyed when preprocessing a container read back from `.h5mu`** — saving
+  stores `var` string columns as categorical, and on pandas 3 `.str.split` over a categorical
+  returns the *repr* of the split list, so the following `explode` did nothing:
+  `infer_protein` reported `protein_group` as `"['P0C7N9', 'D3Z016']"`, and the PTM path, which
+  explodes twice, shredded it further into fragments like `"['A"`. An uninterrupted
+  read-to-analysis run was unaffected, but any path through disk was — including
+  `infer_protein(propagated_from=...)` and the PTM workflow's global reference container.
+- **Filtered-out features reappeared as ghost rows** — removing features leaves their categories
+  behind, and grouping over unobserved categories added an empty `protein_group` entry to
+  `uns['peptide_map']` and a phantom feature row whose quantification read `0` rather than missing.
+  Summarisation now returns only groups the data actually contains.
+
 ## [0.3.0] - 2026-08-11
 
 The headline changes are limma moderated-t differential expression (now the default), model-based
@@ -138,4 +154,5 @@ metadata, one canonical accession form across readers, and sparse-in / sparse-ou
 - **`add_filter` accepted duplicate filter names**, letting one filter silently shadow another.
 - **`split_tmt` operated on the `feature` modality instead of `psm`.**
 
+[0.3.1]: https://github.com/bertis-informatics/msmu/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/bertis-informatics/msmu/compare/0.2.10...v0.3.0

--- a/msmu/_preprocessing/_infer_protein.py
+++ b/msmu/_preprocessing/_infer_protein.py
@@ -10,6 +10,7 @@ import scipy.sparse as sp
 from .._core._provenance import uns_logger
 from .._core._status import AnnDataFlags, MuDataStatus
 from .._utils._anndata import _require_columns
+from .._utils._pandas import split_delimited_strings
 from ..logging_utils import get_logger
 
 logger = get_logger(__name__)
@@ -299,7 +300,7 @@ def _get_map_df(
     """
     # Split proteins and explode the DataFrame
     map_df = pd.DataFrame({"protein": proteins, "peptide": peptides})
-    map_df["protein"] = map_df["protein"].str.split(";")
+    map_df["protein"] = split_delimited_strings(map_df["protein"], ";")
     map_df = map_df.explode("protein").drop_duplicates().reset_index(drop=True)
 
     return map_df.sort_values("protein").reset_index(drop=True)
@@ -317,7 +318,7 @@ def _get_peptide_df(map_df: pd.DataFrame) -> pd.DataFrame:
     """
     # Group by peptide and count the number of proteins
     peptide_df = map_df[["protein", "peptide"]]
-    peptide_df = peptide_df.groupby("peptide", as_index=False, observed=False).count()
+    peptide_df = peptide_df.groupby("peptide", as_index=False, observed=True).count()
     peptide_df["is_unique"] = peptide_df["protein"] == 1
 
     return peptide_df
@@ -341,7 +342,7 @@ def _get_protein_df(map_df: pd.DataFrame, peptide_df: pd.DataFrame) -> pd.DataFr
 
     # Count shared & unique peptides for each protein
     protein_df = (
-        data.groupby(GROUP_COLS, observed=False)
+        data.groupby(GROUP_COLS, observed=True)
         .agg(
             shared_peptides=("is_unique", lambda x: (~x).sum()),
             unique_peptides=("is_unique", "sum"),
@@ -750,7 +751,7 @@ def _make_peptide_map(map_df: pd.DataFrame) -> pd.DataFrame:
     peptide_map = (
         map_df[["peptide", "protein"]]
         .drop_duplicates()
-        .groupby("peptide", as_index=False, observed=False)
+        .groupby("peptide", as_index=False, observed=True)
         .agg({"protein": lambda x: ";".join(x)})
         .rename(columns={"protein": "protein_group"})
     )

--- a/msmu/_preprocessing/_summarisation.py
+++ b/msmu/_preprocessing/_summarisation.py
@@ -8,6 +8,7 @@ import scipy.sparse as sp
 
 from ..logging_utils import get_logger
 from .._core._blockdiag import aggregate_features_by_group, dense_block, is_sparse, to_dense_df
+from .._utils._pandas import split_delimited_strings
 from ._filter import _mask_boolean_filter
 
 # for type checking only
@@ -472,7 +473,7 @@ class Aggregator:
         agg_id_df: pd.DataFrame = self._id_df.copy()
         col_to_groupby = self._col_to_groupby
 
-        agg_id_df = agg_id_df.groupby(col_to_groupby, observed=False).agg(**self._id_agg_dict)
+        agg_id_df = agg_id_df.groupby(col_to_groupby, observed=True).agg(**self._id_agg_dict)
 
         agg_id_df = agg_id_df.rename_axis(index=None)
 
@@ -485,7 +486,7 @@ class Aggregator:
         sample_columns = self._quant_df.columns
         agg_quant_df: pd.DataFrame = self._quant_df.copy()
         agg_quant_df[self._col_to_groupby] = self._id_df[self._col_to_groupby]
-        grouped_quant = agg_quant_df.groupby(self._col_to_groupby, observed=False)
+        grouped_quant = agg_quant_df.groupby(self._col_to_groupby, observed=True)
 
         # Matrix rollups operate on each group's full feature-by-sample submatrix, so they cannot
         # be expressed as a column-wise pandas aggregation and are applied per group instead.
@@ -524,7 +525,7 @@ class Aggregator:
                 f"got {self._agg_method!r}."
             )
         feature_groups = self._id_df[self._col_to_groupby].to_numpy()
-        group_order = self._id_df.groupby(self._col_to_groupby, observed=False).size().index.to_numpy()
+        group_order = self._id_df.groupby(self._col_to_groupby, observed=True).size().index.to_numpy()
         groups, aggregated = aggregate_features_by_group(
             self._quant_df.matrix,
             feature_groups,
@@ -536,7 +537,7 @@ class Aggregator:
 
     def aggregate_decoy(self) -> pd.DataFrame:
         agg_decoy_df: pd.DataFrame = self._decoy_id_df.copy()
-        agg_decoy_df = agg_decoy_df.groupby(self._col_to_groupby, observed=False).agg(**self._decoy_agg_dict)
+        agg_decoy_df = agg_decoy_df.groupby(self._col_to_groupby, observed=True).agg(**self._decoy_agg_dict)
 
         agg_decoy_df = agg_decoy_df.rename_axis(index=None)
 
@@ -829,15 +830,13 @@ class PtmSummarisationPrep(SummarisationPrep):
         return pep_labed_data
 
     def _explode_protein_groups(self, pep_labed_data: pd.DataFrame) -> pd.DataFrame:
-        pep_labed_data["_prot_gr"] = pep_labed_data["protein_group"]
-        pep_labed_data["_prot_gr"] = pep_labed_data["_prot_gr"].str.split(";")
+        pep_labed_data["_prot_gr"] = split_delimited_strings(pep_labed_data["protein_group"], ";")
         exploded_data = pep_labed_data.explode("_prot_gr", ignore_index=True)
 
         return exploded_data
 
     def _explode_protein_group(self, data) -> pd.DataFrame:
-        data["_prots"] = data["_prot_gr"]
-        data["_prots"] = data["_prots"].str.split(",")
+        data["_prots"] = split_delimited_strings(data["_prot_gr"], ",")
         exploded_data = data.explode("_prots", ignore_index=True)
 
         return exploded_data

--- a/msmu/_utils/_pandas.py
+++ b/msmu/_utils/_pandas.py
@@ -1,0 +1,23 @@
+import pandas as pd
+
+
+def split_delimited_strings(values: pd.Series, delimiter: str) -> pd.Series:
+    """Split a delimited string column into lists, tolerating categorical dtype.
+
+    ``write_h5mu`` stores var string columns as categorical, so any column read back from disk is
+    categorical rather than ``str``. Applying ``.str.split`` to a categorical in pandas 3 yields the
+    *repr* of the split list (``"['A', 'B']"``) instead of the list itself, which turns the following
+    ``explode`` into a no-op and silently corrupts the values. Decategorising first keeps the result
+    a real list column, missing values included.
+
+    Parameters:
+        values: string column to split
+        delimiter: separator to split on
+
+    Returns:
+        column of lists aligned to the input index
+    """
+    if isinstance(values.dtype, pd.CategoricalDtype):
+        values = values.astype(str)
+
+    return values.str.split(delimiter)

--- a/tests/test_preprocessing_categorical_var.py
+++ b/tests/test_preprocessing_categorical_var.py
@@ -1,0 +1,124 @@
+"""Preprocessing must behave identically on a MuData read back from .h5mu.
+
+``write_h5mu`` stores var string columns as categorical, so every column of a MuData loaded from
+disk is categorical rather than ``str``. Two independent failure modes followed from that:
+
+1. Value destruction. On pandas 3, ``.str.split`` applied to a categorical returns the *repr* of
+   the split list (``"['P0C7N9', 'D3Z016']"``) instead of the list, so the following ``explode``
+   is a no-op and the accessions are silently fused into one bogus protein. (pandas 2 returned an
+   object column of real lists, so this only surfaced on the pandas 3 stack.) The PTM path explodes
+   twice, on ``;`` then ``,``, which shredded the repr string into fragments like ``"['A"``.
+2. Ghost rows. Filtering features out of ``var`` leaves unused categories behind, and
+   ``groupby(observed=False)`` turns each of those into its own group -- an empty entry in
+   ``uns['peptide_map']`` and a phantom feature row whose quantification reads 0 rather than
+   missing.
+
+These tests pin both behaviours with categorical inputs.
+"""
+
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+from mudata import MuData
+
+import msmu as mm
+from msmu._preprocessing._infer_protein import get_protein_mapping, infer_protein
+from msmu._preprocessing._summarisation import Aggregator, PtmSummarisationPrep
+from msmu._utils._pandas import split_delimited_strings
+
+# pep1/pep4 are shared between two distinguishable proteins, pep2/pep3 are unique to one each -- so
+# the peptides land in different groups and carry different peptide_type values. A fixture of only
+# indistinguishable proteins would collapse to a single group and hide a broken split. The repeated
+# "P1;P2" also matters: anndata only stores a string column as categorical when it has fewer
+# categories than rows, so an all-distinct column would round-trip as ``str`` and prove nothing.
+PEPTIDES = ["pep1", "pep2", "pep3", "pep4"]
+PROTEINS = ["P1;P2", "P1", "P2", "P1;P2"]
+
+
+def _make_peptide_mdata() -> MuData:
+    var = pd.DataFrame(
+        {"stripped_peptide": PEPTIDES, "proteins": PROTEINS},
+        index=[f"f{feature_number}" for feature_number in range(len(PEPTIDES))],
+    )
+    adata = AnnData(
+        X=np.ones((2, len(PEPTIDES)), dtype="float32"),
+        obs=pd.DataFrame(index=["s1", "s2"]),
+        var=var,
+    )
+
+    return MuData({"peptide": adata})
+
+
+def test_split_delimited_strings_splits_categorical_into_lists():
+    values = pd.Series(["A;B", "C", None], dtype="category")
+
+    split_values = split_delimited_strings(values, ";")
+
+    assert split_values.tolist()[:2] == [["A", "B"], ["C"]]
+    assert split_values.isna().iloc[2]
+
+
+def test_infer_protein_is_unchanged_by_an_h5mu_roundtrip(tmp_path):
+    mdata = _make_peptide_mdata()
+    in_memory_var = infer_protein(mdata).mod["peptide"].var
+
+    path = tmp_path / "peptide.h5mu"
+    mdata.write(path)
+    roundtripped = mm.read_h5mu(path)
+    assert isinstance(roundtripped.mod["peptide"].var["proteins"].dtype, pd.CategoricalDtype)
+
+    roundtripped_var = infer_protein(roundtripped).mod["peptide"].var
+
+    assert roundtripped_var["protein_group"].tolist() == in_memory_var["protein_group"].tolist()
+    assert roundtripped_var["peptide_type"].tolist() == in_memory_var["peptide_type"].tolist()
+    # Guard the values themselves, not just their agreement: a split that fails on both sides
+    # would keep them equal while destroying the accessions.
+    assert roundtripped_var["protein_group"].tolist() == ["P1;P2", "P1", "P2", "P1;P2"]
+    assert roundtripped_var["peptide_type"].tolist() == ["shared", "unique", "unique", "shared"]
+
+
+def test_infer_protein_ignores_stale_peptide_categories():
+    """Categories left behind by filtering must not become empty peptide_map rows."""
+    peptides = pd.Series(pd.Categorical(PEPTIDES, categories=[*PEPTIDES, "pep_filtered_out"]))
+
+    peptide_map, _protein_map = get_protein_mapping(peptides, pd.Series(PROTEINS))
+
+    assert peptide_map["peptide"].tolist() == PEPTIDES
+
+
+def test_ptm_explode_splits_categorical_protein_groups():
+    ptm_info = pd.DataFrame(
+        {"protein_group": pd.Series(["P1,P2;P3", "P4"], dtype="category"), "peptide": ["pep1", "pep2"]},
+    )
+
+    exploded_groups = PtmSummarisationPrep._explode_protein_groups(None, ptm_info)
+    exploded_proteins = PtmSummarisationPrep._explode_protein_group(None, exploded_groups)
+
+    assert exploded_groups["_prot_gr"].tolist() == ["P1,P2", "P3", "P4"]
+    assert exploded_proteins["_prots"].tolist() == ["P1", "P2", "P3", "P4"]
+
+
+def test_aggregator_ignores_stale_feature_categories():
+    """A stale category must not become a phantom feature quantified as 0."""
+    identification_df = pd.DataFrame(
+        {
+            "peptide": pd.Categorical(["pep1", "pep2"], categories=["pep1", "pep2", "pep_filtered_out"]),
+            "proteins": ["P1", "P2"],
+            "stripped_peptide": ["pep1", "pep2"],
+            "PEP": [0.01, 0.02],
+        }
+    )
+    quantification_df = pd.DataFrame([[1.0, 2.0], [3.0, 4.0]], columns=["s1", "s2"])
+
+    aggregator = Aggregator.peptide(
+        identification_df,
+        quantification_df,
+        None,
+        "sum",
+        "best_pep",
+        "proteins",
+        "peptide",
+    )
+
+    assert aggregator.aggregate_identification().index.tolist() == ["pep1", "pep2"]
+    assert aggregator.aggregate_quantification().index.tolist() == ["pep1", "pep2"]


### PR DESCRIPTION
## Summary

Reading a MuData back from `.h5mu` turns every `var` string column into a categorical, which is the trigger for both changes below. A single uninterrupted `read → preprocess → analyse` run is unaffected — msmu never categorises `var` in memory (`to_categorical` applies to `obs` only) — but anything that goes through disk is, including `infer_protein(propagated_from=...)`, which calls `read_h5mu` internally, and the PTM workflow, which normally loads a global reference `.h5mu`.

## 1. Fix: value destruction (pandas 3 regression)

On pandas 3, `.str.split` over a categorical returns the *repr* of the split list (`"['P0C7N9', 'D3Z016']"`) instead of the list, so the following `explode` is a no-op and the accessions fuse into one bogus protein. pandas 2.2.3 returned an object column of real lists, so this only surfaces on the pandas 3 stack — measured on both.

- `infer_protein` emitted `protein_group = "['P0C7N9', 'D3Z016']"`.
- The PTM path explodes twice, on `;` then `,`, so the repr string was re-split into fragments: `"A,B;C"` → `["['A", "B'", " 'C']"]`. Reachable through the public API: `to_ptm` reads `adata.var.copy()`, and `protein_group` comes back from disk categorical whenever it has fewer distinct values than rows — which real data always does.

Fixed with a shared `split_delimited_strings` helper that decategorises before splitting. It is now the only pandas `.str.split` in the package.

## 2. Hardening: group only over values the data contains

`observed=False` emits a group for every unused category of a categorical key: an empty `protein_group` entry in `uns['peptide_map']`, and a phantom feature row whose quantification reads `0` rather than missing.

**No route to that state through the public API is known.** anndata drops unused categories when features are subset (`adata[:, mask]` and `_inplace_subset_var` both), and the frames kept in `uns` — including the decoy frame that `apply_filter` row-filters at the pandas level — come back from disk as `str`, never categorical. Both routes were checked and neither reproduces. pandas 3 also already defaults to `observed=True`, so the explicit `observed=False` this replaces was an opt-in to the older behaviour. Treat this as hardening, not a fixed user-visible bug.

The two plotting group-bys keep `observed=False` — they fill empty histogram bins on purpose.

## Changes

| File | Change |
|---|---|
| `msmu/_utils/_pandas.py` (new) | `split_delimited_strings(values, delimiter)` |
| `msmu/_preprocessing/_infer_protein.py` | 1 split site, 3 `observed` flags |
| `msmu/_preprocessing/_summarisation.py` | 2 split sites (PTM), 4 `observed` flags; dropped 2 redundant assignments |
| `tests/test_preprocessing_categorical_var.py` (new) | 5 regression tests |
| `CHANGELOG.md` | 0.3.1 section |

## Behaviour change

Where unused categories exist, summarisation returns fewer rows. Those rows were wrong output (quantified as `0`, not missing), so this is intended.

## Verification

- New regression tests pass; reverting the source fix makes 4 of the 5 fail, so they are not vacuous.
- After a round-trip, `infer_protein` matches the in-memory result exactly: `protein_group = ['P1;P2', 'P1', 'P2', 'P1;P2']`, `peptide_type = ['shared', 'unique', 'unique', 'shared']`.
- Sparse aggregation path checked separately: identification and quantification stay aligned with a stale category present.
- The release workflow's CHANGELOG extraction was run against the new `## [0.3.1]` section and returns the expected body.
- Full suite: 532 passed, 0 failed (notebooks excluded). The 8 notebook failures are `ModuleNotFoundError` and are identical on `dev`.
- `ruff check` clean.