### PR TITLE
docs: correct the reachability claim for the group-by change (BID-160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ from git tags via setuptools-scm.
   explodes twice, shredded it further into fragments like `"['A"`. An uninterrupted
   read-to-analysis run was unaffected, but any path through disk was — including
   `infer_protein(propagated_from=...)` and the PTM workflow's global reference container.
-- **Filtered-out features reappeared as ghost rows** — removing features leaves their categories
-  behind, and grouping over unobserved categories added an empty `protein_group` entry to
-  `uns['peptide_map']` and a phantom feature row whose quantification read `0` rather than missing.
-  Summarisation now returns only groups the data actually contains.
+
+### Changed
+
+- **Protein mapping and summarisation group only over values the data contains.** They previously
+  opted into `groupby(observed=False)`, which emits a group for every unused category of a
+  categorical key — an empty `uns['peptide_map']` entry and a phantom feature row quantified as `0`
+  rather than missing. No route to that state through the public API is known, so this is hardening;
+  it also matches pandas 3's own default.
 
 ## [0.3.0] - 2026-08-11
 

--- a/tests/test_preprocessing_categorical_var.py
+++ b/tests/test_preprocessing_categorical_var.py
@@ -1,19 +1,23 @@
 """Preprocessing must behave identically on a MuData read back from .h5mu.
 
 ``write_h5mu`` stores var string columns as categorical, so every column of a MuData loaded from
-disk is categorical rather than ``str``. Two independent failure modes followed from that:
+disk is categorical rather than ``str``. Two behaviours are pinned here.
 
-1. Value destruction. On pandas 3, ``.str.split`` applied to a categorical returns the *repr* of
-   the split list (``"['P0C7N9', 'D3Z016']"``) instead of the list, so the following ``explode``
-   is a no-op and the accessions are silently fused into one bogus protein. (pandas 2 returned an
-   object column of real lists, so this only surfaced on the pandas 3 stack.) The PTM path explodes
-   twice, on ``;`` then ``,``, which shredded the repr string into fragments like ``"['A"``.
-2. Ghost rows. Filtering features out of ``var`` leaves unused categories behind, and
-   ``groupby(observed=False)`` turns each of those into its own group -- an empty entry in
-   ``uns['peptide_map']`` and a phantom feature row whose quantification reads 0 rather than
-   missing.
+1. Value destruction (a real failure). On pandas 3, ``.str.split`` applied to a categorical returns
+   the *repr* of the split list (``"['P0C7N9', 'D3Z016']"``) instead of the list, so the following
+   ``explode`` is a no-op and the accessions are silently fused into one bogus protein. (pandas 2
+   returned an object column of real lists, so this only surfaced on the pandas 3 stack.) The PTM
+   path explodes twice, on ``;`` then ``,``, which shredded the repr string into fragments like
+   ``"['A"``.
+2. Ghost rows (hardening). A group-by key whose categories include values absent from the rows used
+   to emit a group per unused category -- an empty entry in ``uns['peptide_map']`` and a phantom
+   feature row quantified as 0 rather than missing. No route to that state via the public API was
+   found: anndata drops unused categories when features are subset, and the frames kept in ``uns``
+   come back from disk as ``str``, never categorical. These tests construct the state directly, so
+   they guard the invariant rather than reproduce a reported failure.
 
-These tests pin both behaviours with categorical inputs.
+Note that pandas 3 already defaults ``groupby(observed=True)``; the explicit ``observed=False`` this
+replaced was an opt-in to the older behaviour.
 """
 
 import numpy as np


### PR DESCRIPTION
## Summary

Docs-only follow-up to #27, which merged before this correction was pushed. No source changes — the 0.3.1 code fix is already on `main`.

The ghost-row half of #27 was described as a reproduced failure. It is not, and both routes claimed for it were refuted by measurement:

- **"Filtering features leaves unused categories behind"** — no. anndata drops unused categories when features are subset (`adata[:, mask]` and `_inplace_subset_var` both).
- **The decoy frame** (`apply_filter` row-filters `uns['decoy']` at the pandas level, so its categories would survive) — no. Frames kept in `uns` come back from disk as `str`, never categorical; only `obs`/`var` are categorised.

pandas 3 also already defaults to `observed=True`, so the explicit `observed=False` that #27 replaced was an opt-in to the older behaviour. The change stays — it is correct, matches the library default, and has no regression — but it is hardening, not a fixed user-visible bug.

This moves it from `### Fixed` to `### Changed` in the 0.3.1 CHANGELOG section and rewrites the test module docstring to match. The split-corruption entry is untouched; that one reproduces end to end through the public API.

## Why this blocks the tag

The release workflow builds the GitHub Release body from the `## [0.3.1]` CHANGELOG section, so tagging before this lands would publish the refuted wording.

## Note

Targets `main` directly because the `dev` branch was deleted when #28 merged.