### PR TITLE
BID-261 Upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -49,12 +49,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -73,12 +73,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -156,12 +156,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -188,7 +188,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # The release body is the CHANGELOG section for this version -- what the maintainers actually
       # wrote -- with GitHub's generated pull-request list kept underneath, collapsed.


### PR DESCRIPTION
## Changes

- Upgrade all six `actions/checkout` references from v4 to v5.
- Upgrade all four `actions/setup-python` references from v5 to v6.
- Keep Python 3.13 and all workflow behavior unchanged.

## Verification

- `git diff --check`
- Confirmed no `actions/checkout@v4` or `actions/setup-python@v5` references remain.
- Confirmed six `actions/checkout@v5` and four `actions/setup-python@v6` references.
- Confirmed the v5 and v6 action tags are available upstream.

## Jira

- [BID-261](https://bertis.atlassian.net/browse/BID-261)
