### PR TITLE
BID-262 Avoid duplicate CI runs after pull request merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,6 @@ on:
       - dev
       - main
   push:
-    branches:
-      - dev
-      - main
     tags:
       - "v*.*.*"
   workflow_dispatch:


### PR DESCRIPTION
## Changes

- Stop running the Release workflow on pushes to `dev` and `main`.
- Keep pull request validation for both branches.
- Keep `v*.*.*` tag releases and manual workflow dispatch unchanged.

## Verification

- Workflow YAML syntax validated.
- `git diff --check`
- Confirmed pull request branch filters and release tag filters remain present.
- Confirmed the branch-push filters are removed.

## Trade-off

The `dev` branch is not protected. Direct pushes to `dev` or `main` will no longer trigger CI, so this change assumes changes are integrated through pull requests.

## Jira

- [BID-262](https://bertis.atlassian.net/browse/BID-262)
