### PR TITLE
BID-264 Upgrade artifact actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         run: python -m build
 
       - name: Upload distribution artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-dist
           path: dist/
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Download distribution artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-dist
           path: dist/


### PR DESCRIPTION
## Changes
- Upgrade `actions/upload-artifact` from v4 to v7.
- Upgrade `actions/download-artifact` from v4 to v8.
- Preserve the existing artifact name, path, and release flow.

## Verification
- Confirmed both selected action majors declare the Node 24 runtime upstream.
- Parsed `.github/workflows/release.yml` successfully.
- Ran `git diff --check`.
- PR checks will exercise `upload-artifact@v7`; `download-artifact@v8` remains tag-release-only.

## Compatibility
- The existing archived-directory upload behavior remains the default.
- Download v8 validates artifact digests by default; artifacts transferred within the same workflow should match.

Jira: https://bertis.atlassian.net/browse/BID-264